### PR TITLE
feat(linux): implement real-time power tracking for Linux + NVIDIA GB10 Blackwell

### DIFF
--- a/greenprompt/api.py
+++ b/greenprompt/api.py
@@ -20,7 +20,7 @@ Known issues:
 """
 
 from flask import Flask, render_template, request, jsonify, Response
-from analytics import (
+from greenprompt.analytics import (
     load_usage_data,
     total_prompts_energy_usage,
     energy_usage_timeline,
@@ -37,7 +37,6 @@ import logging
 import json
 from plotly.utils import PlotlyJSONEncoder
 import requests
-from greenprompt.samplerMac import PowerMonitor
 
 # global variable to hold the power monitor instance
 global monitor
@@ -156,7 +155,7 @@ def ollama_proxy(subpath):
     incorrect — Ollama's base path is /api/<subpath>. This is a known bug.
     """
     # Construct the target URL on the Ollama server (default port 11434)
-    target_url = f"http://localhost:11434/ollama/api/{subpath}"
+    target_url = f"http://localhost:11434/api/{subpath}"
     # Forward headers, preserving content type and authorization
     headers = {
         key: value
@@ -190,9 +189,18 @@ def ollama_proxy(subpath):
 
 
 if __name__ == "__main__":
+    import argparse as _argparse
+    _parser = _argparse.ArgumentParser()
+    _parser.add_argument("--port", type=int, default=5000)
+    _args = _parser.parse_args()
+
     if constants.OS == "Darwin":
-        # Initialize the power monitor for macOS
+        from greenprompt.samplerMac import PowerMonitor
         monitor = PowerMonitor()
         monitor.start()
+    elif constants.OS == "Linux":
+        from greenprompt.samplerLinux import LinuxPowerMonitor
+        monitor = LinuxPowerMonitor(cpu_tdp_w=getattr(constants, "CPU_TDP_W", 40.0))
+        monitor.start()
     logging.info("Starting API server...")
-    app.run(debug=False)
+    app.run(host="127.0.0.1", port=_args.port, debug=False)

--- a/greenprompt/api.py
+++ b/greenprompt/api.py
@@ -76,7 +76,14 @@ def handle_prompt():
     if not prompt:
         logging.error("Prompt is required but not provided.")
         return jsonify({"error": "Prompt is required"}), 400
-    result = run_prompt(prompt, model, monitor=monitor)
+    try:
+        result = run_prompt(prompt, model, monitor=monitor)
+    except RuntimeError as e:
+        logging.error(f"run_prompt failed: {e}")
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        logging.error(f"Unexpected error in run_prompt: {e}")
+        return jsonify({"error": "Internal server error", "detail": str(e)}), 500
     return jsonify(result)
 
 

--- a/greenprompt/api.py
+++ b/greenprompt/api.py
@@ -69,9 +69,9 @@ logging.getLogger().addHandler(console_handler)
 @app.route("/api/prompt", methods=["POST"])
 def handle_prompt():
     """Run a prompt through core.run_prompt() and return energy/token metrics."""
-    data = request.get_json()
+    data = request.get_json(silent=True) or {}
     prompt = data.get("prompt", "")
-    model = data.get("model", "llama2")
+    model = data.get("model", "llama3.2:latest")
     logging.info(f"Received prompt: {prompt} for model: {model}")
     if not prompt:
         logging.error("Prompt is required but not provided.")

--- a/greenprompt/cli.py
+++ b/greenprompt/cli.py
@@ -89,6 +89,9 @@ def main():
     p_prompt.add_argument(
         "--model", type=str, default="llama2", help="Model to use (default: llama2)"
     )
+    p_prompt.add_argument(
+        "--port", type=int, default=5000, help="API server port (default: 5000)"
+    )
     # monitor command
     p_mon = subparsers.add_parser(
         "monitor", help="Display the last N prompt usage entries"
@@ -103,7 +106,10 @@ def main():
     )
 
     # dashboard command
-    subparsers.add_parser("dashboard", help="Open the dashboard in your browser")
+    p_dash = subparsers.add_parser("dashboard", help="Open the dashboard in your browser")
+    p_dash.add_argument(
+        "--port", type=int, default=5000, help="API server port (default: 5000)"
+    )
 
     # stop command
     p_stop = subparsers.add_parser("stop", help="Stop the API server")
@@ -135,7 +141,7 @@ def main():
     elif args.command == "prompt":
         # Make api call to run the prompt
         print("Running prompt...")
-        url = "http://127.0.0.1:5000/api/prompt"
+        url = f"http://127.0.0.1:{args.port}/api/prompt"
         payload = {"prompt": args.prompt, "model": args.model}
         try:
             response = requests.post(url, json=payload)
@@ -180,7 +186,7 @@ def main():
 
     elif args.command == "dashboard":
         print("Starting the dashboard...")
-        url = "http://localhost:5000/dashboard"
+        url = f"http://localhost:{args.port}/dashboard"
         try:
             webbrowser.open(url)
         except Exception as e:

--- a/greenprompt/cli.py
+++ b/greenprompt/cli.py
@@ -121,10 +121,11 @@ def main():
     args = parser.parse_args()
 
     if args.command == "setup":
-        # Verify sudo privileges
-        if os.geteuid() != 0:
+        # sudo only needed on macOS (powermetrics requires root)
+        from greenprompt import constants as _c
+        if _c.OS == "Darwin" and os.geteuid() != 0:
             print(
-                "Error: 'setup' requires sudo privileges. Please run 'sudo greenprompt setup'"
+                "Error: 'setup' requires sudo privileges on macOS. Please run 'sudo greenprompt setup'"
             )
             sys.exit(1)
         # Run setup.py file
@@ -134,10 +135,10 @@ def main():
         print("✅ Setup complete: database initialized and constants saved")
 
     elif args.command == "run":
-        # Verify sudo privileges
-        if os.geteuid() != 0:
+        from greenprompt import constants as _c
+        if _c.OS == "Darwin" and os.geteuid() != 0:
             print(
-                "Error: 'run' requires sudo privileges. Please run 'sudo greenprompt run'"
+                "Error: 'run' requires sudo privileges on macOS. Please run 'sudo greenprompt run'"
             )
             sys.exit(1)
         print(f"Starting API server on port {args.port}...")
@@ -198,10 +199,10 @@ def main():
             print(f"Error opening dashboard: {e}")
 
     elif args.command == "stop":
-        # Verify sudo privileges
-        if os.geteuid() != 0:
+        from greenprompt import constants as _c
+        if _c.OS == "Darwin" and os.geteuid() != 0:
             print(
-                "Error: 'stop' requires sudo privileges. Please run 'sudo greenprompt stop'"
+                "Error: 'stop' requires sudo privileges on macOS. Please run 'sudo greenprompt stop'"
             )
             sys.exit(1)
         port = args.port

--- a/greenprompt/cli.py
+++ b/greenprompt/cli.py
@@ -87,7 +87,7 @@ def main():
     )
     p_prompt.add_argument("prompt", type=str, help="The prompt text to send")
     p_prompt.add_argument(
-        "--model", type=str, default="llama2", help="Model to use (default: llama2)"
+        "--model", type=str, default="llama3.2:latest", help="Model to use (default: llama3.2:latest)"
     )
     p_prompt.add_argument(
         "--port", type=int, default=5000, help="API server port (default: 5000)"
@@ -146,6 +146,9 @@ def main():
         try:
             response = requests.post(url, json=payload)
             data = response.json()
+            if "error" in data:
+                print(f"Error: {data['error']}")
+                sys.exit(1)
             print("\nResponse:\n" + data.get("response", ""))
             print("\n--- Prompt usage data ---")
             print(f"Prompt tokens: {data.get('prompt_tokens')}")
@@ -158,9 +161,13 @@ def main():
             print(f"GPU power (W): {data.get('gpu_power_w (W)')}")
             print(f"Combined power (W): {data.get('combined_power_w (W)')}")
             print(f"Energy used (Wh): {data.get('total_energy (Wh)')}")
+        except requests.exceptions.ConnectionError:
+            print(f"Error: cannot connect to API server on port {args.port}.")
+            print(f"Start it first with: greenprompt run --port {args.port}")
+            sys.exit(1)
         except Exception as e:
-            print(f"Error connecting to API: {e}")
-            print("Is the API server running? Try 'greenprompt run'.")
+            print(f"Error: {e}")
+            sys.exit(1)
 
     elif args.command == "monitor":
         entries = get_prompt_usage(start_time=None, end_time=None, model=None)

--- a/greenprompt/cli.py
+++ b/greenprompt/cli.py
@@ -8,13 +8,18 @@ managed by spawning/killing processes on the configured port.
 
 Subcommands: setup, run, prompt, monitor, score, dashboard, stop, log_api.
 See README.md for full usage examples and flag reference.
+
+Sudo policy: no greenprompt command requires the caller to be root. On macOS,
+powermetrics requires root — samplerMac.py calls `sudo powermetrics`
+internally. Run `sudo greenprompt setup` once to configure passwordless sudo
+for powermetrics; thereafter all commands run as a normal user.
 """
 
 import argparse
-import os
 import requests
 import sys
 import subprocess
+import webbrowser
 from greenprompt.dbconn import get_prompt_usage
 from greenprompt.scoreBasic import score_prompt
 
@@ -29,9 +34,6 @@ def run_api(port):
 
     Args:
         port: Integer port number to bind the Flask server to.
-    """
-    """
-    Run the API server on the specified port.
     """
     # Check if the port is in use
     try:
@@ -59,7 +61,7 @@ def run_api(port):
 def main():
     parser = argparse.ArgumentParser(
         prog="greenprompt",
-        description="GreenPrompt CLI: track energy usage of LLM prompts on macOS",
+        description="GreenPrompt CLI: track energy usage of LLM prompts",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -121,26 +123,12 @@ def main():
     args = parser.parse_args()
 
     if args.command == "setup":
-        # sudo only needed on macOS (powermetrics requires root)
-        from greenprompt import constants as _c
-        if _c.OS == "Darwin" and os.geteuid() != 0:
-            print(
-                "Error: 'setup' requires sudo privileges on macOS. Please run 'sudo greenprompt setup'"
-            )
-            sys.exit(1)
-        # Run setup.py file
         from greenprompt.setup import main as setup_main
 
         setup_main()
         print("✅ Setup complete: database initialized and constants saved")
 
     elif args.command == "run":
-        from greenprompt import constants as _c
-        if _c.OS == "Darwin" and os.geteuid() != 0:
-            print(
-                "Error: 'run' requires sudo privileges on macOS. Please run 'sudo greenprompt run'"
-            )
-            sys.exit(1)
         print(f"Starting API server on port {args.port}...")
         run_api(port=args.port)
 
@@ -166,7 +154,7 @@ def main():
             print(f"Energy used (Wh): {data.get('total_energy (Wh)')}")
         except Exception as e:
             print(f"Error connecting to API: {e}")
-            print("Is the API server running? Try 'sudo greenprompt run'.")
+            print("Is the API server running? Try 'greenprompt run'.")
 
     elif args.command == "monitor":
         entries = get_prompt_usage(start_time=None, end_time=None, model=None)
@@ -192,19 +180,14 @@ def main():
 
     elif args.command == "dashboard":
         print("Starting the dashboard...")
-        # Open a tab in a web browser at http://localhost:5000/dashboard
+        url = "http://localhost:5000/dashboard"
         try:
-            subprocess.run(["open", "http://localhost:5000/dashboard"], check=True)
+            webbrowser.open(url)
         except Exception as e:
             print(f"Error opening dashboard: {e}")
+            print(f"Open manually: {url}")
 
     elif args.command == "stop":
-        from greenprompt import constants as _c
-        if _c.OS == "Darwin" and os.geteuid() != 0:
-            print(
-                "Error: 'stop' requires sudo privileges on macOS. Please run 'sudo greenprompt stop'"
-            )
-            sys.exit(1)
         port = args.port
         print(f"Stopping API server on port {port}...")
         try:

--- a/greenprompt/constants.py
+++ b/greenprompt/constants.py
@@ -1,9 +1,24 @@
-# greenprompt/constants.py
-# This is a template file. It is overwritten during setup.
-OS = ""
-OS_VERSION = ""
-PLATFORM = ""
-MACHINE = ""
-PROCESSOR = ""
-OLLAMA_URL = "http://127.0.0.1:11434"
-# ...etc
+# Auto-generated constants file
+OS = 'Linux'
+OS_VERSION = '#21-Ubuntu SMP PREEMPT_DYNAMIC Wed May 27 19:14:05 UTC 2026'
+PLATFORM = 'Linux-6.17.0-1021-nvidia-aarch64-with-glibc2.39'
+MACHINE = 'aarch64'
+PROCESSOR = 'aarch64'
+CPU = 'Cortex-X925'
+CPU_CORES_PHYSICAL = 20
+CPU_CORES_TOTAL = 20
+CPU_FREQUENCY_CURRENT = '3354.00 MHz'
+CPU_FREQUENCY_MIN = '858.00 MHz'
+CPU_FREQUENCY_MAX = '3354.00 MHz'
+RAM_TOTAL = '121.63 GB'
+DISK_TOTAL = '915.32 GB'
+DISK_USED = '73.99 GB'
+DISK_FREE = '794.77 GB'
+HOSTNAME = 'gx10-17eb'
+IP_ADDRESS = '127.0.0.1'
+OLLAMA_URL = 'http://127.0.0.1:11434'
+# CPU TDP used in linear_tdp fallback mode only. In arm_biglittle or rapl mode
+# this value is not used for sampling. Adjust to match your hardware.
+CPU_TDP_W = 23.0
+# 'rapl' = Intel/AMD direct energy counter measurement; 'estimated' = ARM/other
+CPU_POWER_SOURCE = 'estimated'

--- a/greenprompt/core.py
+++ b/greenprompt/core.py
@@ -103,10 +103,11 @@ def run_prompt(prompt, model="llama2", monitor=False):
     print(f"Current PID: {current_pid}")
 
     # Check for GPU and its usage
+    gpu_usage = "No GPU detected"
     if has_gpu():
         print("GPU detected.")
         gpu_usage = get_gpu_usage()
-        print("GPU Usage: " + gpu_usage)
+        print("GPU Usage: " + str(gpu_usage))
     else:
         print("No GPU detected.")
 

--- a/greenprompt/dbconn.py
+++ b/greenprompt/dbconn.py
@@ -65,6 +65,15 @@ def init_db():
     conn.close()
 
 
+def _first_not_none(data: dict, *keys):
+    """Return the first value from data that is not None, checking keys in order."""
+    for key in keys:
+        val = data.get(key)
+        if val is not None:
+            return val
+    return None
+
+
 def save_prompt_usage(data: dict):
     """
     Saves a prompt usage record to the prompt_usage table.
@@ -76,7 +85,7 @@ def save_prompt_usage(data: dict):
         """
         INSERT INTO prompt_usage (
             timestamp, prompt, prompt_score, prompt_score_details, response, model, prompt_tokens,
-            completion_tokens, total_tokens, energy_estimate_prompt, energy_estimate_tokens ,duration_sec, energy_wh,
+            completion_tokens, total_tokens, energy_estimate_prompt, energy_estimate_tokens, duration_sec, energy_wh,
             baseline_power_w, baseline_energy_wh,
             cpu_power_w, gpu_power_w, combined_power_w, system_info
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -94,12 +103,12 @@ def save_prompt_usage(data: dict):
             data.get("energy_estimate_prompt"),
             data.get("energy_estimate_tokens"),
             data.get("duration_sec"),
-            data.get("total_energy (Wh)") or data.get("energy_wh"),
-            data.get("baseline_power (W)") or data.get("baseline_power_w"),
-            data.get("baseline_energy (Wh)") or data.get("baseline_energy_wh"),
-            data.get("cpu_power_w (W)") or data.get("cpu_power_w"),
-            data.get("gpu_power_w (W)") or data.get("gpu_power_w"),
-            data.get("combined_power_w (W)") or data.get("combined_power_w"),
+            _first_not_none(data, "total_energy (Wh)", "energy_wh"),
+            _first_not_none(data, "baseline_power (W)", "baseline_power_w"),
+            _first_not_none(data, "baseline_energy (Wh)", "baseline_energy_wh"),
+            _first_not_none(data, "cpu_power_w (W)", "cpu_power_w"),
+            _first_not_none(data, "gpu_power_w (W)", "gpu_power_w"),
+            _first_not_none(data, "combined_power_w (W)", "combined_power_w"),
             system_info,
         ),
     )

--- a/greenprompt/samplerLinux.py
+++ b/greenprompt/samplerLinux.py
@@ -1,33 +1,52 @@
 """
-samplerLinux.py — Continuous Linux power sampling via psutil and nvidia-smi.
+samplerLinux.py — Continuous Linux power sampling via psutil, sysfs, and nvidia-smi.
 
-Provides LinuxPowerMonitor, a daemon thread that samples CPU utilization
-(via psutil) and GPU power draw (via nvidia-smi) every second, maintaining
-a 10-minute ring buffer identical in structure to samplerMac.PowerMonitor.
+Provides LinuxPowerMonitor, a daemon thread that samples CPU and GPU power every
+second, maintaining a 10-minute ring buffer identical in structure to
+samplerMac.PowerMonitor.
 
-CPU power is estimated as: cpu_percent / 100 * cpu_tdp_w
-GPU power is read directly from nvidia-smi (watts).
+CPU measurement strategy (auto-detected at startup, priority order):
+  1. rapl       — Intel/AMD only: reads energy_uj counter delta from sysfs.
+                  Ground-truth watts, no estimation.
+  2. arm_biglittle — ARM big.LITTLE (e.g. Cortex-X925 + A725): per-cluster
+                  frequency-squared model. Reads scaling_cur_freq from sysfs.
+                  Better than linear because power ∝ V²f and V scales with freq.
+  3. linear_tdp — Fallback: cpu_percent / 100 * cpu_tdp_w.
 
-RAPL is not used because this system is ARM-based (Cortex-X925); RAPL
-requires Intel or AMD CPUs. nvidia-smi is the only direct power reading
-available on this hardware.
+GPU measurement:
+  One long-running `nvidia-smi dmon -s p -d 1` process (NvidiaDmonReader)
+  instead of a subprocess fork every second. Falls back to per-call subprocess
+  if dmon fails to start.
+
+Thread safety: self.samples is protected by self._lock. Stop uses threading.Event
+so stop() returns immediately instead of waiting up to 1s for sleep() to expire.
 
 This module is Linux-only. For macOS, see samplerMac.py.
 """
 
 from collections import deque
+import glob
+import os
 import threading
 import time
 import subprocess
 import psutil
 
 
+# Per-cluster TDP and idle power estimates for known ARM big.LITTLE configurations.
+# Keyed by cluster max frequency in MHz (int). Used only in arm_biglittle mode.
+_CLUSTER_TDP = {
+    2808: {"tdp_w": 8.0,  "idle_w": 0.5},   # Cortex-A725 efficiency cores
+    3900: {"tdp_w": 23.0, "idle_w": 1.0},   # Cortex-X925 performance cores
+}
+
+
 def _parse_nvidia_power(raw: str) -> float:
     """
     Parse a power.draw value from nvidia-smi CSV output.
 
-    nvidia-smi may return '[N/A]' or 'N/A' for unsupported fields.
-    Returns 0.0 in those cases.
+    nvidia-smi may return '[N/A]' or 'N/A' for unsupported fields (e.g. GB10
+    unified memory). Returns 0.0 in those cases.
 
     Args:
         raw: Stripped string from nvidia-smi (e.g. '3.92', '[N/A]', 'N/A').
@@ -44,6 +63,97 @@ def _parse_nvidia_power(raw: str) -> float:
         return 0.0
 
 
+def _detect_rapl_path() -> "str | None":
+    """Return the RAPL energy_uj sysfs path if Intel/AMD RAPL is available, else None."""
+    direct = "/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj"
+    if os.path.exists(direct):
+        return direct
+    candidates = glob.glob("/sys/class/powercap/intel-rapl*/intel-rapl*:0/energy_uj")
+    return candidates[0] if candidates else None
+
+
+def _detect_cpu_clusters() -> dict:
+    """
+    Detect ARM big.LITTLE CPU clusters by grouping CPUs by max frequency.
+
+    Uses psutil.cpu_freq(percpu=True) to read per-CPU max frequencies and groups
+    CPU indices by max_mhz. Returns a dict only if more than one distinct max
+    frequency is found (i.e. a heterogeneous cluster arrangement).
+
+    Returns:
+        {max_mhz_int: [cpu_indices]} if big.LITTLE detected, {} otherwise.
+    """
+    try:
+        freqs = psutil.cpu_freq(percpu=True)
+        if not freqs or len(freqs) < 2:
+            return {}
+        clusters = {}
+        for i, f in enumerate(freqs):
+            clusters.setdefault(int(f.max), []).append(i)
+        return clusters if len(clusters) > 1 else {}
+    except Exception:
+        return {}
+
+
+class NvidiaDmonReader:
+    """
+    Wraps a single long-running `nvidia-smi dmon` process for efficient GPU power polling.
+
+    Instead of forking nvidia-smi on every sample tick, one process streams output
+    continuously. A daemon thread reads lines and updates _power_w under a lock.
+    Callers read get_power() with no subprocess overhead.
+
+    dmon output format (columns vary by -s flag; -s p gives power and temp):
+        # gpu   pwr  gtemp  mtemp    sm   mem   enc   dec   jpg   ofa
+        # Idx     W      C      C     %     %     %     %     %     %
+            0     4     40      -     2     -     0     0     -     -
+
+    Column index 1 (0-indexed after split) = power in watts.
+    Header lines start with '#' and are skipped.
+    """
+
+    def __init__(self):
+        self._power_w = 0.0
+        self._lock = threading.Lock()
+        self._failed = False
+        self._proc = None
+        try:
+            self._proc = subprocess.Popen(
+                ["nvidia-smi", "dmon", "-s", "p", "-d", "1"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            self._thread = threading.Thread(target=self._read_loop, daemon=True)
+            self._thread.start()
+        except (FileNotFoundError, OSError):
+            self._failed = True
+
+    def _read_loop(self):
+        for line in self._proc.stdout:
+            if line.startswith("#") or not line.strip():
+                continue
+            parts = line.split()
+            if len(parts) >= 2:
+                try:
+                    with self._lock:
+                        self._power_w = float(parts[1])
+                except ValueError:
+                    pass
+
+    def get_power(self) -> float:
+        """Return the most recently read GPU power in watts."""
+        with self._lock:
+            return self._power_w
+
+    def stop(self):
+        """Terminate the dmon process. The reader thread exits naturally."""
+        if self._proc:
+            self._proc.terminate()
+            self._proc.wait()
+            self._proc = None
+
+
 class LinuxPowerMonitor:
     """
     Background daemon thread that samples Linux CPU/GPU power every second.
@@ -52,52 +162,80 @@ class LinuxPowerMonitor:
     the last `window_size` seconds — identical interface to samplerMac.PowerMonitor
     so that measure_power_linux() can use the same logic as measure_power_mac().
 
-    CPU power = psutil.cpu_percent() / 100 * cpu_tdp_w  (estimated)
-    GPU power = nvidia-smi power.draw (direct measurement)
+    CPU mode is auto-detected at construction time:
+      - "rapl":          Intel/AMD energy counter (ground truth)
+      - "arm_biglittle": per-cluster frequency-squared model
+      - "linear_tdp":    cpu_percent * cpu_tdp_w fallback
+
+    GPU mode:
+      - NvidiaDmonReader (single long-running process) if nvidia-smi is available
+      - Per-call subprocess fallback if dmon fails to start
 
     Usage:
-        monitor = LinuxPowerMonitor(cpu_tdp_w=40)
+        monitor = LinuxPowerMonitor(cpu_tdp_w=23.0)
         monitor.start()
         time.sleep(5)   # warm up before first prompt
-        # ... run workload ...
         # Use sysUsage.measure_power_linux(start, end, monitor) to get metrics.
         monitor.stop()
 
     Attributes:
         samples: deque of (float timestamp, dict{cpu_power_w, gpu_power_w,
-            combined_power_w}) tuples.
+            combined_power_w}) tuples. Protected by self._lock.
         running: bool, True while the background thread is active.
-        cpu_tdp_w: float, assumed CPU thermal design power in watts.
+        cpu_tdp_w: float, CPU TDP used in linear_tdp fallback mode.
+        _cpu_mode: str, one of "rapl", "arm_biglittle", "linear_tdp".
     """
 
     def __init__(self, sample_interval: int = 1, window_size: int = 600, cpu_tdp_w: float = 40.0):
         """
         Args:
             sample_interval: Seconds between samples (default 1).
-            window_size: Max samples to retain; 600 = 10-minute window (default).
-            cpu_tdp_w: CPU thermal design power in watts used for estimation
-                (default 40W for ARM Cortex-X925). Edit CPU_TDP_W in constants.py
-                to match your hardware.
+            window_size: Max samples to retain; 600 = 10-minute window.
+            cpu_tdp_w: CPU TDP in watts for linear_tdp fallback mode. Ignored when
+                RAPL or arm_biglittle is detected. Edit CPU_TDP_W in constants.py.
         """
         self.samples = deque(maxlen=window_size)
         self.running = False
         self.sample_interval = sample_interval
         self.cpu_tdp_w = cpu_tdp_w
-        self._gpu_available = None  # None = not yet checked
-        self._gpu_unavailable_warned = False
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
         self.thread = threading.Thread(target=self._run, daemon=True)
-        # Prime psutil CPU measurement — first call always returns 0.0
-        psutil.cpu_percent(interval=0.1)
+
+        # CPU mode detection: rapl > arm_biglittle > linear_tdp
+        rapl_path = _detect_rapl_path()
+        if rapl_path:
+            self._cpu_mode = "rapl"
+            self._rapl_path = rapl_path
+            self._rapl_max_path = rapl_path.replace("energy_uj", "max_energy_range_uj")
+            self._rapl_last_energy = None
+            self._rapl_last_ts = None
+        else:
+            clusters = _detect_cpu_clusters()
+            if clusters:
+                self._cpu_mode = "arm_biglittle"
+                self._clusters = clusters  # {max_mhz_int: [cpu_indices]}
+            else:
+                self._cpu_mode = "linear_tdp"
+
+        self._gpu_available = None
+        self._gpu_unavailable_warned = False
+        self._dmon = None
+        # Prime psutil per-CPU measurement — first call always returns 0.0
+        psutil.cpu_percent(percpu=True, interval=0.1)
 
     def _run(self):
         while self.running:
             power = self.sample_once()
             if power:
-                self.samples.append((time.time(), power))
-            time.sleep(self.sample_interval)
+                with self._lock:
+                    self.samples.append((time.time(), power))
+            # threading.Event.wait wakes immediately when stop() sets the event,
+            # avoiding the up-to-1s sleep() latency of the old implementation.
+            self._stop_event.wait(timeout=self.sample_interval)
 
     def _check_gpu(self) -> bool:
-        """Return True if nvidia-smi is available and reports a GPU."""
+        """Return True if nvidia-smi is available and reports a GPU. Cached after first check."""
         if self._gpu_available is not None:
             return self._gpu_available
         try:
@@ -112,22 +250,95 @@ class LinuxPowerMonitor:
                 self._gpu_unavailable_warned = True
         return self._gpu_available
 
-    def sample_once(self) -> dict | None:
+    def _sample_cpu_rapl(self) -> float:
         """
-        Take a single power sample using psutil (CPU) and nvidia-smi (GPU).
+        Read CPU package power via RAPL energy counter delta (Intel/AMD only).
+
+        Reads energy_uj, computes delta since last call, divides by elapsed seconds.
+        Returns 0.0 on the first call (no prior baseline) and on read errors.
+        Handles counter overflow via max_energy_range_uj.
+        """
+        try:
+            with open(self._rapl_path) as f:
+                energy_uj = int(f.read().strip())
+            ts = time.time()
+            if self._rapl_last_energy is None:
+                self._rapl_last_energy, self._rapl_last_ts = energy_uj, ts
+                return 0.0
+            delta_uj = energy_uj - self._rapl_last_energy
+            if delta_uj < 0:  # counter wrapped around
+                try:
+                    with open(self._rapl_max_path) as f:
+                        max_range = int(f.read().strip())
+                except (OSError, ValueError):
+                    max_range = 2 ** 32 * 1000  # safe default
+                delta_uj += max_range
+            delta_s = ts - self._rapl_last_ts
+            self._rapl_last_energy, self._rapl_last_ts = energy_uj, ts
+            return (delta_uj / 1_000_000.0) / delta_s if delta_s > 0 else 0.0
+        except (OSError, ValueError):
+            return 0.0
+
+    def _sample_cpu_biglittle(self) -> float:
+        """
+        Estimate CPU power for ARM big.LITTLE by summing per-cluster contributions.
+
+        For each cluster: power = idle_W + util * (tdp - idle) * (cur_freq/max_freq)²
+        The freq² term models the fact that dynamic power scales with V²f and
+        voltage tracks frequency on most ARM platforms.
+
+        Reads scaling_cur_freq from sysfs per CPU (cheap file reads, no subprocess).
+        """
+        cpu_pcts = psutil.cpu_percent(percpu=True, interval=None)
+        total = 0.0
+        n_clusters = len(self._clusters)
+        for max_mhz, cpu_indices in self._clusters.items():
+            info = _CLUSTER_TDP.get(
+                max_mhz,
+                {"tdp_w": self.cpu_tdp_w / n_clusters, "idle_w": 0.2},
+            )
+            # Read current frequency for each CPU in this cluster (kHz → MHz)
+            freqs = []
+            for i in cpu_indices:
+                try:
+                    with open(f"/sys/devices/system/cpu/cpu{i}/cpufreq/scaling_cur_freq") as f:
+                        freqs.append(int(f.read().strip()) / 1000.0)
+                except OSError:
+                    freqs.append(float(max_mhz))
+            freq_ratio = min(1.0, (sum(freqs) / len(freqs)) / max_mhz)
+            util = (
+                sum(cpu_pcts[i] for i in cpu_indices if i < len(cpu_pcts))
+                / len(cpu_indices)
+            )
+            total += (
+                info["idle_w"]
+                + (util / 100.0) * (info["tdp_w"] - info["idle_w"]) * (freq_ratio ** 2)
+            )
+        return total
+
+    def sample_once(self) -> "dict | None":
+        """
+        Take a single power sample.
+
+        CPU: dispatches to _sample_cpu_rapl, _sample_cpu_biglittle, or linear_tdp.
+        GPU: reads from NvidiaDmonReader if active, else falls back to per-call nvidia-smi.
 
         Returns:
             dict with keys cpu_power_w, gpu_power_w, combined_power_w,
             or None if sampling fails entirely.
         """
         try:
-            # CPU: non-blocking, uses delta since last call
-            cpu_pct = psutil.cpu_percent(interval=None)
-            cpu_power_w = (cpu_pct / 100.0) * self.cpu_tdp_w
+            if self._cpu_mode == "rapl":
+                cpu_power_w = self._sample_cpu_rapl()
+            elif self._cpu_mode == "arm_biglittle":
+                cpu_power_w = self._sample_cpu_biglittle()
+            else:
+                cpu_power_w = (psutil.cpu_percent(interval=None) / 100.0) * self.cpu_tdp_w
 
-            # GPU: direct power reading via nvidia-smi
             gpu_power_w = 0.0
-            if self._check_gpu():
+            if self._dmon is not None:
+                gpu_power_w = self._dmon.get_power()
+            elif self._check_gpu():
                 try:
                     raw = subprocess.check_output(
                         [
@@ -141,31 +352,46 @@ class LinuxPowerMonitor:
                 except (subprocess.CalledProcessError, FileNotFoundError, OSError):
                     gpu_power_w = 0.0
 
-            combined_power_w = cpu_power_w + gpu_power_w
             return {
                 "cpu_power_w": cpu_power_w,
                 "gpu_power_w": gpu_power_w,
-                "combined_power_w": combined_power_w,
+                "combined_power_w": cpu_power_w + gpu_power_w,
             }
         except Exception as e:
             print(f"LinuxPowerMonitor: error sampling: {e}")
             return None
 
     def start(self):
-        """Start the background sampling thread."""
+        """Start the background sampling thread and GPU dmon reader."""
         print("Starting Linux power monitor...")
+        print(f"  CPU mode: {self._cpu_mode}")
+        try:
+            self._dmon = NvidiaDmonReader()
+            if self._dmon._failed:
+                print("  GPU: dmon unavailable, using per-call nvidia-smi fallback")
+                self._dmon = None
+            else:
+                print("  GPU: nvidia-smi dmon streaming reader active")
+        except Exception:
+            self._dmon = None
         self.running = True
         self.thread.start()
 
     def stop(self):
-        """Stop the background sampling thread and wait for it to exit."""
+        """Stop the background sampling thread and dmon reader."""
         print("Stopping Linux power monitor...")
         self.running = False
+        self._stop_event.set()
         self.thread.join()
+        if self._dmon:
+            self._dmon.stop()
+            self._dmon = None
 
-    def get_range_average(self, start_ts: float, end_ts: float) -> float | None:
+    def get_range_average(self, start_ts: float, end_ts: float) -> "float | None":
         """
         Compute the average combined power (W) for samples in [start_ts, end_ts].
+
+        Thread-safe: takes a snapshot of self.samples under self._lock before filtering.
 
         Args:
             start_ts: Unix timestamp for the start of the range.
@@ -174,8 +400,7 @@ class LinuxPowerMonitor:
         Returns:
             Average combined_power_w as a float, or None if no samples found.
         """
-        relevant = [s for ts, s in self.samples if start_ts <= ts <= end_ts]
-        if not relevant:
-            return None
-        combined = [r["combined_power_w"] for r in relevant]
-        return sum(combined) / len(combined)
+        with self._lock:
+            snapshot = list(self.samples)
+        relevant = [s["combined_power_w"] for ts, s in snapshot if start_ts <= ts <= end_ts]
+        return sum(relevant) / len(relevant) if relevant else None

--- a/greenprompt/samplerLinux.py
+++ b/greenprompt/samplerLinux.py
@@ -1,0 +1,181 @@
+"""
+samplerLinux.py — Continuous Linux power sampling via psutil and nvidia-smi.
+
+Provides LinuxPowerMonitor, a daemon thread that samples CPU utilization
+(via psutil) and GPU power draw (via nvidia-smi) every second, maintaining
+a 10-minute ring buffer identical in structure to samplerMac.PowerMonitor.
+
+CPU power is estimated as: cpu_percent / 100 * cpu_tdp_w
+GPU power is read directly from nvidia-smi (watts).
+
+RAPL is not used because this system is ARM-based (Cortex-X925); RAPL
+requires Intel or AMD CPUs. nvidia-smi is the only direct power reading
+available on this hardware.
+
+This module is Linux-only. For macOS, see samplerMac.py.
+"""
+
+from collections import deque
+import threading
+import time
+import subprocess
+import psutil
+
+
+def _parse_nvidia_power(raw: str) -> float:
+    """
+    Parse a power.draw value from nvidia-smi CSV output.
+
+    nvidia-smi may return '[N/A]' or 'N/A' for unsupported fields.
+    Returns 0.0 in those cases.
+
+    Args:
+        raw: Stripped string from nvidia-smi (e.g. '3.92', '[N/A]', 'N/A').
+
+    Returns:
+        Power in watts as a float, or 0.0 if not available/parseable.
+    """
+    raw = raw.strip()
+    if not raw or raw in ("[N/A]", "N/A", "Unknown Error"):
+        return 0.0
+    try:
+        return float(raw)
+    except ValueError:
+        return 0.0
+
+
+class LinuxPowerMonitor:
+    """
+    Background daemon thread that samples Linux CPU/GPU power every second.
+
+    Maintains a fixed-size deque of (timestamp, sample_dict) tuples covering
+    the last `window_size` seconds — identical interface to samplerMac.PowerMonitor
+    so that measure_power_linux() can use the same logic as measure_power_mac().
+
+    CPU power = psutil.cpu_percent() / 100 * cpu_tdp_w  (estimated)
+    GPU power = nvidia-smi power.draw (direct measurement)
+
+    Usage:
+        monitor = LinuxPowerMonitor(cpu_tdp_w=40)
+        monitor.start()
+        time.sleep(5)   # warm up before first prompt
+        # ... run workload ...
+        # Use sysUsage.measure_power_linux(start, end, monitor) to get metrics.
+        monitor.stop()
+
+    Attributes:
+        samples: deque of (float timestamp, dict{cpu_power_w, gpu_power_w,
+            combined_power_w}) tuples.
+        running: bool, True while the background thread is active.
+        cpu_tdp_w: float, assumed CPU thermal design power in watts.
+    """
+
+    def __init__(self, sample_interval: int = 1, window_size: int = 600, cpu_tdp_w: float = 40.0):
+        """
+        Args:
+            sample_interval: Seconds between samples (default 1).
+            window_size: Max samples to retain; 600 = 10-minute window (default).
+            cpu_tdp_w: CPU thermal design power in watts used for estimation
+                (default 40W for ARM Cortex-X925). Edit CPU_TDP_W in constants.py
+                to match your hardware.
+        """
+        self.samples = deque(maxlen=window_size)
+        self.running = False
+        self.sample_interval = sample_interval
+        self.cpu_tdp_w = cpu_tdp_w
+        self._gpu_available = None  # None = not yet checked
+        self._gpu_unavailable_warned = False
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        # Prime psutil CPU measurement — first call always returns 0.0
+        psutil.cpu_percent(interval=0.1)
+
+    def _run(self):
+        while self.running:
+            power = self.sample_once()
+            if power:
+                self.samples.append((time.time(), power))
+            time.sleep(self.sample_interval)
+
+    def _check_gpu(self) -> bool:
+        """Return True if nvidia-smi is available and reports a GPU."""
+        if self._gpu_available is not None:
+            return self._gpu_available
+        try:
+            result = subprocess.check_output(
+                ["nvidia-smi", "-L"], stderr=subprocess.DEVNULL
+            ).decode().strip()
+            self._gpu_available = bool(result)
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+            self._gpu_available = False
+            if not self._gpu_unavailable_warned:
+                print("LinuxPowerMonitor: nvidia-smi not available — GPU power will be 0.0 W")
+                self._gpu_unavailable_warned = True
+        return self._gpu_available
+
+    def sample_once(self) -> dict | None:
+        """
+        Take a single power sample using psutil (CPU) and nvidia-smi (GPU).
+
+        Returns:
+            dict with keys cpu_power_w, gpu_power_w, combined_power_w,
+            or None if sampling fails entirely.
+        """
+        try:
+            # CPU: non-blocking, uses delta since last call
+            cpu_pct = psutil.cpu_percent(interval=None)
+            cpu_power_w = (cpu_pct / 100.0) * self.cpu_tdp_w
+
+            # GPU: direct power reading via nvidia-smi
+            gpu_power_w = 0.0
+            if self._check_gpu():
+                try:
+                    raw = subprocess.check_output(
+                        [
+                            "nvidia-smi",
+                            "--query-gpu=power.draw",
+                            "--format=csv,nounits,noheader",
+                        ],
+                        stderr=subprocess.DEVNULL,
+                    ).decode()
+                    gpu_power_w = _parse_nvidia_power(raw)
+                except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+                    gpu_power_w = 0.0
+
+            combined_power_w = cpu_power_w + gpu_power_w
+            return {
+                "cpu_power_w": cpu_power_w,
+                "gpu_power_w": gpu_power_w,
+                "combined_power_w": combined_power_w,
+            }
+        except Exception as e:
+            print(f"LinuxPowerMonitor: error sampling: {e}")
+            return None
+
+    def start(self):
+        """Start the background sampling thread."""
+        print("Starting Linux power monitor...")
+        self.running = True
+        self.thread.start()
+
+    def stop(self):
+        """Stop the background sampling thread and wait for it to exit."""
+        print("Stopping Linux power monitor...")
+        self.running = False
+        self.thread.join()
+
+    def get_range_average(self, start_ts: float, end_ts: float) -> float | None:
+        """
+        Compute the average combined power (W) for samples in [start_ts, end_ts].
+
+        Args:
+            start_ts: Unix timestamp for the start of the range.
+            end_ts: Unix timestamp for the end of the range.
+
+        Returns:
+            Average combined_power_w as a float, or None if no samples found.
+        """
+        relevant = [s for ts, s in self.samples if start_ts <= ts <= end_ts]
+        if not relevant:
+            return None
+        combined = [r["combined_power_w"] for r in relevant]
+        return sum(combined) / len(combined)

--- a/greenprompt/samplerMac.py
+++ b/greenprompt/samplerMac.py
@@ -3,10 +3,19 @@ samplerMac.py — Continuous macOS power sampling via powermetrics.
 
 Provides PowerMonitor, a daemon thread that calls `sudo powermetrics` every
 second and maintains a 10-minute ring buffer of CPU/GPU/combined power
-readings. Requires macOS and root privileges (for powermetrics).
+readings.
 
-This module is macOS-only. For Linux/Windows, see sysUsage.py stubs and
-docs/platform-support.md for the implementation roadmap.
+powermetrics requires root, but the greenprompt process itself does NOT need
+to run as root. Instead, configure passwordless sudo for powermetrics once:
+
+    sudo greenprompt setup
+
+That command writes /etc/sudoers.d/greenprompt so subsequent `sudo powermetrics`
+calls in this module succeed without a password prompt. After setup, all
+greenprompt commands (run, stop, prompt, dashboard) work as a normal user.
+
+This module is macOS-only. For Linux/Windows, see samplerLinux.py and
+docs/platform-support.md.
 """
 
 from collections import deque
@@ -14,6 +23,27 @@ import threading
 import time
 import subprocess
 from greenprompt.sysUsage import parse_powermetrics_output
+
+_SUDOERS_HINT = (
+    "Power sampling requires passwordless sudo for powermetrics.\n"
+    "Run once to configure it:\n"
+    "    sudo greenprompt setup\n"
+    "Until then, energy readings will be zero."
+)
+
+
+def _check_powermetrics_sudo() -> bool:
+    """Return True if `sudo -n powermetrics` succeeds without a password prompt."""
+    try:
+        subprocess.run(
+            ["sudo", "-n", "powermetrics", "--version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        return True
+    except Exception:
+        return False
 
 
 class PowerMonitor:
@@ -41,6 +71,7 @@ class PowerMonitor:
         self.running = False
         self.sample_interval = sample_interval
         self.thread = threading.Thread(target=self._run, daemon=True)
+        self._sudo_ok = None  # checked lazily on first start()
 
     def _run(self):
         while self.running:
@@ -86,6 +117,9 @@ class PowerMonitor:
             return None
 
     def start(self):
+        self._sudo_ok = _check_powermetrics_sudo()
+        if not self._sudo_ok:
+            print(f"Warning: {_SUDOERS_HINT}")
         print("Starting power monitor...")
         self.running = True
         self.thread.start()

--- a/greenprompt/setup.py
+++ b/greenprompt/setup.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from greenprompt.sysUsage import get_system_info
 from greenprompt.dbconn import init_db
 import subprocess
@@ -71,6 +72,47 @@ def detect_cpu_tdp_w() -> float:
     return 40.0  # default for Cortex-X925
 
 
+def configure_powermetrics_sudoers():
+    """
+    Write /etc/sudoers.d/greenprompt to allow passwordless powermetrics.
+
+    Only runs on macOS. Requires the current process to be root (i.e. the user
+    ran `sudo greenprompt setup`). If this succeeds, subsequent `greenprompt run`
+    calls work without sudo because samplerMac.py calls `sudo powermetrics`
+    internally and the sudoers rule removes the password prompt.
+
+    Prints instructions and returns False if the write fails (e.g. not root).
+    """
+    if platform.system() != "Darwin":
+        return True
+
+    powermetrics_path = "/usr/bin/powermetrics"
+    sudoers_file = "/etc/sudoers.d/greenprompt"
+    try:
+        import pwd
+        # Identify the real (non-root) user: SUDO_USER env var set by sudo
+        real_user = os.environ.get("SUDO_USER") or pwd.getpwuid(os.getuid()).pw_name
+        rule = f"{real_user} ALL=(ALL) NOPASSWD: {powermetrics_path}\n"
+        with open(sudoers_file, "w") as f:
+            f.write(rule)
+        # sudoers.d files must be mode 0440
+        os.chmod(sudoers_file, 0o440)
+        print(f"✅ Configured passwordless sudo for powermetrics ({sudoers_file})")
+        print("   You can now run 'greenprompt run' without sudo.")
+        return True
+    except PermissionError:
+        print(
+            "ℹ️  Skipping powermetrics sudo configuration (not running as root).\n"
+            "   For accurate power tracking on macOS, run setup once with sudo:\n"
+            "       sudo greenprompt setup\n"
+            "   After that, 'greenprompt run' works without sudo."
+        )
+        return False
+    except Exception as e:
+        print(f"Warning: could not configure sudoers for powermetrics: {e}")
+        return False
+
+
 def check_ollama():
     """
     Check if Ollama is installed. If not, install it and return the port.
@@ -135,6 +177,10 @@ def main():
         # Adjust this value to match your hardware if you know the actual TDP.
         py_file.write(f"CPU_TDP_W = {cpu_tdp_w}\n")
     print(f"✅ System information saved to {constants_py_path} (CPU_TDP_W={cpu_tdp_w}W)")
+
+    # On macOS, configure passwordless sudo for powermetrics so `greenprompt run`
+    # works without sudo after this one-time setup.
+    configure_powermetrics_sudoers()
 
     # Download required NLTK data
     print("Downloading required NLTK data...")

--- a/greenprompt/setup.py
+++ b/greenprompt/setup.py
@@ -33,6 +33,44 @@ def sanitize_key(key):
     return key.upper().replace(" ", "_").replace("(", "").replace(")", "")
 
 
+def detect_cpu_tdp_w() -> float:
+    """
+    Estimate CPU TDP in watts for the current machine.
+
+    Checks known CPU brand strings against a lookup table. Falls back to
+    40W, a reasonable default for ARM Cortex-X925 (20-core) systems.
+
+    Returns:
+        Estimated CPU TDP in watts as a float.
+    """
+    try:
+        import cpuinfo
+        brand = cpuinfo.get_cpu_info().get("brand_raw", "").lower()
+        # Known TDP estimates by CPU family
+        tdp_map = [
+            ("cortex-x925", 40.0),
+            ("cortex-x4",   30.0),
+            ("cortex-x3",   25.0),
+            ("cortex-x2",   20.0),
+            ("cortex-x1",   15.0),
+            ("a78",         10.0),
+            ("i9-",         65.0),
+            ("i7-",         45.0),
+            ("i5-",         35.0),
+            ("i3-",         25.0),
+            ("ryzen 9",     65.0),
+            ("ryzen 7",     45.0),
+            ("ryzen 5",     35.0),
+            ("apple m",     20.0),
+        ]
+        for keyword, tdp in tdp_map:
+            if keyword in brand:
+                return tdp
+    except Exception:
+        pass
+    return 40.0  # default for Cortex-X925
+
+
 def check_ollama():
     """
     Check if Ollama is installed. If not, install it and return the port.
@@ -85,6 +123,7 @@ def main():
 
     # Save system information to constants.py
     constants_py_path = os.path.join(os.getcwd(), "constants.py")
+    cpu_tdp_w = detect_cpu_tdp_w()
     with open(constants_py_path, "w") as py_file:
         py_file.write("# Auto-generated constants file\n")
         for key, value in system_info.items():
@@ -92,7 +131,10 @@ def main():
             py_file.write(f"{sanitized_key} = {repr(value)}\n")
         # Add ollama URL
         py_file.write(f"OLLAMA_URL = {repr(OLLAMA_URL)}\n")
-    print(f"✅ System information saved to {constants_py_path}")
+        # CPU TDP estimate used by LinuxPowerMonitor for CPU energy estimation.
+        # Adjust this value to match your hardware if you know the actual TDP.
+        py_file.write(f"CPU_TDP_W = {cpu_tdp_w}\n")
+    print(f"✅ System information saved to {constants_py_path} (CPU_TDP_W={cpu_tdp_w}W)")
 
     # Download required NLTK data
     print("Downloading required NLTK data...")

--- a/greenprompt/setup.py
+++ b/greenprompt/setup.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import platform
 from greenprompt.sysUsage import get_system_info
@@ -49,7 +50,8 @@ def detect_cpu_tdp_w() -> float:
         brand = cpuinfo.get_cpu_info().get("brand_raw", "").lower()
         # Known TDP estimates by CPU family
         tdp_map = [
-            ("cortex-x925", 40.0),
+            ("cortex-x925", 23.0),   # 10-core P-cluster (NVIDIA Grace / Snapdragon X Elite)
+            ("cortex-a725",  8.0),   # 10-core E-cluster
             ("cortex-x4",   30.0),
             ("cortex-x3",   25.0),
             ("cortex-x2",   20.0),
@@ -166,6 +168,15 @@ def main():
     # Save system information to constants.py
     constants_py_path = os.path.join(os.getcwd(), "constants.py")
     cpu_tdp_w = detect_cpu_tdp_w()
+
+    # Detect CPU power measurement source for informational display
+    cpu_power_source = "estimated"
+    if platform.system() == "Linux":
+        rapl_files = glob.glob("/sys/class/powercap/intel-rapl*/intel-rapl*:0/energy_uj")
+        direct_rapl = "/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj"
+        if rapl_files or os.path.exists(direct_rapl):
+            cpu_power_source = "rapl"
+
     with open(constants_py_path, "w") as py_file:
         py_file.write("# Auto-generated constants file\n")
         for key, value in system_info.items():
@@ -173,10 +184,12 @@ def main():
             py_file.write(f"{sanitized_key} = {repr(value)}\n")
         # Add ollama URL
         py_file.write(f"OLLAMA_URL = {repr(OLLAMA_URL)}\n")
-        # CPU TDP estimate used by LinuxPowerMonitor for CPU energy estimation.
-        # Adjust this value to match your hardware if you know the actual TDP.
+        # CPU TDP estimate used by LinuxPowerMonitor in linear_tdp fallback mode.
+        # In arm_biglittle or rapl mode this value is not used for sampling.
         py_file.write(f"CPU_TDP_W = {cpu_tdp_w}\n")
-    print(f"✅ System information saved to {constants_py_path} (CPU_TDP_W={cpu_tdp_w}W)")
+        # Informational: 'rapl' (Intel/AMD direct measurement) or 'estimated' (ARM/other)
+        py_file.write(f"CPU_POWER_SOURCE = {repr(cpu_power_source)}\n")
+    print(f"✅ System information saved to {constants_py_path} (CPU_TDP_W={cpu_tdp_w}W, CPU_POWER_SOURCE={cpu_power_source!r})")
 
     # On macOS, configure passwordless sudo for powermetrics so `greenprompt run`
     # works without sudo after this one-time setup.

--- a/greenprompt/sysUsage.py
+++ b/greenprompt/sysUsage.py
@@ -5,13 +5,11 @@ Provides:
 - get_system_info(): CPU, RAM, disk, OS metadata as a dict.
 - measure_power_for_pid(): Dispatches to the correct OS-specific power function.
 - measure_power_mac(): Reads from a PowerMonitor sample buffer (macOS only).
-- measure_power_linux(): Placeholder — not yet implemented.
+- measure_power_linux(): Reads from a LinuxPowerMonitor sample buffer (Linux only).
 - measure_power_windows(): Placeholder — not yet implemented.
 - has_gpu(): Detects GPU presence on all platforms.
 - get_gpu_usage(): Returns GPU utilization stats (Linux/Windows via nvidia-smi).
 - parse_powermetrics_output(): Parses raw macOS powermetrics text output.
-
-For Linux/Windows implementation roadmap, see docs/platform-support.md.
 """
 
 import platform
@@ -93,19 +91,24 @@ def measure_power_linux(start_time: float, end_time: float, monitor=None) -> dic
     """
     Compute power and energy metrics for a Linux prompt run from LinuxPowerMonitor samples.
 
-    Mirrors measure_power_mac() exactly — reads (timestamp, sample_dict) tuples
-    from monitor.samples and averages the window matching [start_time, end_time].
-    Uses the 60 seconds before start_time as the idle baseline.
+    Takes a single thread-safe snapshot of monitor.samples, then filters for the
+    prompt window [start_time, end_time] and a 60-second idle baseline before it.
+
+    Short-prompt interpolation: if the prompt duration is shorter than the sampler
+    interval (typically 1s), the window may contain zero samples. In that case,
+    up to two neighboring samples (one before, one after the window, within
+    2 × sample_interval seconds) are used as a proxy. The result includes
+    "extrapolated": True when this path is taken.
 
     Args:
         start_time: Unix timestamp when the prompt started.
         end_time: Unix timestamp when the prompt ended.
-        monitor: LinuxPowerMonitor instance with a populated samples deque,
-            or None to return zero values with a warning.
+        monitor: LinuxPowerMonitor instance, or None to return zeros with a warning.
 
     Returns:
-        dict with keys: cpu_power_w, gpu_power_w, combined_power_w,
-        duration_sec, energy_wh, baseline_power_w, baseline_energy_wh.
+        dict with keys: cpu_power_w, gpu_power_w, combined_power_w, duration_sec,
+        energy_wh, baseline_power_w, baseline_energy_wh.
+        Optional key: extrapolated (True if neighboring samples were used).
     """
     duration = end_time - start_time
 
@@ -123,41 +126,64 @@ def measure_power_linux(start_time: float, end_time: float, monitor=None) -> dic
         print("Warning: LinuxPowerMonitor not running — energy_wh will be 0. Start with 'greenprompt run'.")
         return _zero
 
+    # Single thread-safe snapshot — avoids two separate deque iterations that
+    # could be inconsistent if the sampler appends between them.
+    if hasattr(monitor, "_lock"):
+        with monitor._lock:
+            all_samples = list(monitor.samples)
+    else:
+        all_samples = list(getattr(monitor, "samples", []))
+
     baseline_start = start_time - 60
-    baseline_samples = [
-        s for ts, s in getattr(monitor, "samples", [])
-        if baseline_start <= ts <= start_time
-    ]
-    prompt_samples = [
-        s for ts, s in getattr(monitor, "samples", [])
-        if start_time <= ts <= end_time
-    ]
+    baseline_samples = [s for ts, s in all_samples if baseline_start <= ts <= start_time]
+    prompt_samples = [s for ts, s in all_samples if start_time <= ts <= end_time]
 
+    # Short-prompt interpolation: find nearest neighbors when window is empty
+    extrapolated = False
     if not prompt_samples:
-        print("Warning: No power samples in prompt window — monitor may need more warm-up time.")
-        return _zero
+        sample_interval = getattr(monitor, "sample_interval", 1)
+        threshold = 2 * sample_interval
 
-    avg_cpu = sum(s.get("cpu_power_w", 0.0) for s in prompt_samples) / len(prompt_samples)
-    avg_gpu = sum(s.get("gpu_power_w", 0.0) for s in prompt_samples) / len(prompt_samples)
+        before = [(ts, s) for ts, s in all_samples if ts < start_time]
+        after  = [(ts, s) for ts, s in all_samples if ts > end_time]
+
+        neighbors = []
+        if before and (start_time - before[-1][0]) <= threshold:
+            neighbors.append(before[-1][1])
+        if after and (after[0][0] - end_time) <= threshold:
+            neighbors.append(after[0][1])
+
+        if neighbors:
+            prompt_samples = neighbors
+            extrapolated = True
+        else:
+            print("Warning: No power samples in prompt window — monitor may need more warm-up time.")
+            return _zero
+
+    avg_cpu      = sum(s.get("cpu_power_w", 0.0)      for s in prompt_samples) / len(prompt_samples)
+    avg_gpu      = sum(s.get("gpu_power_w", 0.0)      for s in prompt_samples) / len(prompt_samples)
     avg_combined = sum(s.get("combined_power_w", 0.0) for s in prompt_samples) / len(prompt_samples)
-    energy_wh = (avg_combined * duration) / 3600.0
+    energy_wh    = (avg_combined * duration) / 3600.0
 
     if baseline_samples:
-        baseline_avg = sum(s.get("combined_power_w", 0.0) for s in baseline_samples) / len(baseline_samples)
+        baseline_avg       = sum(s.get("combined_power_w", 0.0) for s in baseline_samples) / len(baseline_samples)
         baseline_energy_wh = (baseline_avg * 60.0) / 3600.0
     else:
-        baseline_avg = 0.0
+        baseline_avg       = 0.0
         baseline_energy_wh = 0.0
 
-    return {
-        "cpu_power_w": avg_cpu,
-        "gpu_power_w": avg_gpu,
-        "combined_power_w": avg_combined,
-        "duration_sec": duration,
-        "energy_wh": energy_wh,
-        "baseline_power_w": baseline_avg,
+    result = {
+        "cpu_power_w":        avg_cpu,
+        "gpu_power_w":        avg_gpu,
+        "combined_power_w":   avg_combined,
+        "duration_sec":       duration,
+        "energy_wh":          energy_wh,
+        "baseline_power_w":   baseline_avg,
         "baseline_energy_wh": baseline_energy_wh,
     }
+    if extrapolated:
+        result["extrapolated"] = True
+    return result
 
 def measure_power_windows(pid, start_time, end_time):  # noqa: ARG001
     """

--- a/greenprompt/sysUsage.py
+++ b/greenprompt/sysUsage.py
@@ -89,20 +89,77 @@ def measure_power_mac(start_time, end_time, monitor=None):
         "baseline_energy_wh": baseline_energy_wh,
     }
 
-def measure_power_linux(pid, start_time, end_time):
+def measure_power_linux(start_time: float, end_time: float, monitor=None) -> dict:
     """
-    Placeholder: Uses psutil sensors_battery for Linux (not process-specific).
-    """
-    try:
-        # No direct per-process power usage; placeholder using battery info
-        power_start = psutil.sensors_battery().power_plugged if psutil.sensors_battery() else None
-        time.sleep(end_time - start_time)
-        power_end = psutil.sensors_battery().power_plugged if psutil.sensors_battery() else None
-        return f"Power plugged start: {power_start}, end: {power_end}"
-    except Exception as e:
-        return f"Error collecting power metrics on Linux: {e}"
+    Compute power and energy metrics for a Linux prompt run from LinuxPowerMonitor samples.
 
-def measure_power_windows(pid, start_time, end_time):
+    Mirrors measure_power_mac() exactly — reads (timestamp, sample_dict) tuples
+    from monitor.samples and averages the window matching [start_time, end_time].
+    Uses the 60 seconds before start_time as the idle baseline.
+
+    Args:
+        start_time: Unix timestamp when the prompt started.
+        end_time: Unix timestamp when the prompt ended.
+        monitor: LinuxPowerMonitor instance with a populated samples deque,
+            or None to return zero values with a warning.
+
+    Returns:
+        dict with keys: cpu_power_w, gpu_power_w, combined_power_w,
+        duration_sec, energy_wh, baseline_power_w, baseline_energy_wh.
+    """
+    duration = end_time - start_time
+
+    _zero = {
+        "cpu_power_w": 0.0,
+        "gpu_power_w": 0.0,
+        "combined_power_w": 0.0,
+        "duration_sec": duration,
+        "energy_wh": 0.0,
+        "baseline_power_w": 0.0,
+        "baseline_energy_wh": 0.0,
+    }
+
+    if monitor is None:
+        print("Warning: LinuxPowerMonitor not running — energy_wh will be 0. Start with 'greenprompt run'.")
+        return _zero
+
+    baseline_start = start_time - 60
+    baseline_samples = [
+        s for ts, s in getattr(monitor, "samples", [])
+        if baseline_start <= ts <= start_time
+    ]
+    prompt_samples = [
+        s for ts, s in getattr(monitor, "samples", [])
+        if start_time <= ts <= end_time
+    ]
+
+    if not prompt_samples:
+        print("Warning: No power samples in prompt window — monitor may need more warm-up time.")
+        return _zero
+
+    avg_cpu = sum(s.get("cpu_power_w", 0.0) for s in prompt_samples) / len(prompt_samples)
+    avg_gpu = sum(s.get("gpu_power_w", 0.0) for s in prompt_samples) / len(prompt_samples)
+    avg_combined = sum(s.get("combined_power_w", 0.0) for s in prompt_samples) / len(prompt_samples)
+    energy_wh = (avg_combined * duration) / 3600.0
+
+    if baseline_samples:
+        baseline_avg = sum(s.get("combined_power_w", 0.0) for s in baseline_samples) / len(baseline_samples)
+        baseline_energy_wh = (baseline_avg * 60.0) / 3600.0
+    else:
+        baseline_avg = 0.0
+        baseline_energy_wh = 0.0
+
+    return {
+        "cpu_power_w": avg_cpu,
+        "gpu_power_w": avg_gpu,
+        "combined_power_w": avg_combined,
+        "duration_sec": duration,
+        "energy_wh": energy_wh,
+        "baseline_power_w": baseline_avg,
+        "baseline_energy_wh": baseline_energy_wh,
+    }
+
+def measure_power_windows(pid, start_time, end_time):  # noqa: ARG001
     """
     Placeholder: Uses WMI for Windows. Not process-specific.
     """
@@ -119,31 +176,39 @@ def measure_power_for_pid(pid, start_time, end_time, monitor=None):
     """
     Dispatch power measurement to the appropriate OS-specific function.
 
-    On macOS, reads from the provided PowerMonitor sample buffer.
-    On Linux and Windows, returns a placeholder string (not yet implemented).
+    On macOS, reads from the PowerMonitor sample buffer (samplerMac.py).
+    On Linux, reads from the LinuxPowerMonitor sample buffer (samplerLinux.py).
+    On Windows, returns a zero dict (not yet implemented).
 
     Args:
-        pid: Process ID (used on Linux/Windows for future per-process sampling).
+        pid: Process ID (reserved for future per-process filtering).
         start_time: Unix timestamp when the workload started.
         end_time: Unix timestamp when the workload ended.
-        monitor: PowerMonitor instance (required on macOS; ignored on others).
+        monitor: Platform monitor instance (PowerMonitor or LinuxPowerMonitor).
 
     Returns:
-        On macOS: dict with cpu_power_w, gpu_power_w, combined_power_w,
-            duration_sec, energy_wh, baseline_power_w, baseline_energy_wh.
-        On Linux/Windows: str explaining the limitation.
+        dict with cpu_power_w, gpu_power_w, combined_power_w, duration_sec,
+        energy_wh, baseline_power_w, baseline_energy_wh. Never returns a string.
     """
     os_type = constants.OS
     if os_type == "Darwin":
         return measure_power_mac(start_time, end_time, monitor)
     elif os_type == "Linux":
-        #return measure_power_linux(pid, start_time, end_time)
-        return "Linux power measurement not implemented."
+        return measure_power_linux(start_time, end_time, monitor)
     elif os_type == "Windows":
-        #return measure_power_windows(pid, start_time, end_time)
-        return "Windows power measurement not implemented."
+        duration = end_time - start_time
+        return {
+            "cpu_power_w": 0.0, "gpu_power_w": 0.0, "combined_power_w": 0.0,
+            "duration_sec": duration, "energy_wh": 0.0,
+            "baseline_power_w": 0.0, "baseline_energy_wh": 0.0,
+        }
     else:
-        return "Unsupported OS for power measurement."
+        duration = end_time - start_time
+        return {
+            "cpu_power_w": 0.0, "gpu_power_w": 0.0, "combined_power_w": 0.0,
+            "duration_sec": duration, "energy_wh": 0.0,
+            "baseline_power_w": 0.0, "baseline_energy_wh": 0.0,
+        }
     
 def has_gpu():
     """
@@ -175,25 +240,44 @@ def has_gpu():
     
 def get_gpu_usage():
     """
-    Return current GPU utilization statistics.
+    Return current GPU utilization and power statistics.
 
-    Linux/Windows: queries nvidia-smi for utilization %, memory used, total.
-    macOS: returns a not-supported message (powermetrics handles GPU on macOS).
+    Linux/Windows: queries nvidia-smi for power draw, utilization, memory,
+    and temperature. Handles [N/A] fields gracefully.
+    macOS: returns a not-supported message (powermetrics covers GPU on macOS).
 
     Returns:
-        str — CSV-formatted nvidia-smi output on Linux/Windows, or an
-        explanatory string on macOS or on error.
+        str — formatted GPU stats string, or an explanatory string on error.
     """
     os_type = constants.OS
     try:
         if os_type == "Darwin":
             return "GPU usage monitoring not supported on macOS"
         elif os_type in ["Linux", "Windows"]:
-            output = subprocess.check_output(["nvidia-smi", "--query-gpu=utilization.gpu,memory.used,memory.total", "--format=csv,nounits,noheader"]).decode()
-            return output
+            output = subprocess.check_output(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=name,power.draw,power.limit,utilization.gpu,"
+                    "utilization.memory,memory.used,memory.total,temperature.gpu",
+                    "--format=csv,noheader",
+                ],
+                stderr=subprocess.DEVNULL,
+            ).decode().strip()
+            # Parse and reformat so [N/A] values are visible but don't crash callers
+            parts = [p.strip() for p in output.split(",")]
+            labels = ["name", "power_draw", "power_limit", "gpu_util",
+                      "mem_util", "mem_used", "mem_total", "temperature"]
+            stats = dict(zip(labels, parts))
+            return (
+                f"GPU: {stats.get('name', 'N/A')} | "
+                f"Power: {stats.get('power_draw', 'N/A')} / {stats.get('power_limit', 'N/A')} | "
+                f"GPU util: {stats.get('gpu_util', 'N/A')} | "
+                f"Mem: {stats.get('mem_used', 'N/A')} / {stats.get('mem_total', 'N/A')} | "
+                f"Temp: {stats.get('temperature', 'N/A')}"
+            )
         else:
             return "GPU usage monitoring not supported on this OS."
-    except Exception as e:
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
         return f"Error retrieving GPU usage: {e}"
     
 def parse_powermetrics_output(output: str, duration_sec: float) -> dict:

--- a/tests/test_linux_stress.py
+++ b/tests/test_linux_stress.py
@@ -1,0 +1,898 @@
+"""
+Stress tests and edge-case coverage for Linux power monitoring.
+
+Covers:
+  - CPU arch simulation (RAPL / ARM big.LITTLE / single-cluster / linear_tdp fallback)
+  - sysfs failure modes (missing files, bad values, RAPL counter overflow)
+  - NvidiaDmonReader (unavailable, garbled output, process death mid-run)
+  - LinuxPowerMonitor thread safety (concurrent read/write under lock)
+  - LinuxPowerMonitor lifecycle (rapid start/stop, deque rotation, no-GPU path)
+  - measure_power_linux edge cases (None monitor, 0 samples, zero duration,
+    start==end, no baseline, short-prompt interpolation threshold)
+  - _parse_nvidia_power (all N/A variants, non-numeric, negative, large values)
+  - API: empty prompt, missing JSON body, timeframe missing params
+"""
+
+import threading
+import time
+import unittest
+from collections import deque
+from unittest.mock import MagicMock, patch, mock_open
+
+
+# ---------------------------------------------------------------------------
+# Helpers / lightweight fakes
+# ---------------------------------------------------------------------------
+
+def _make_monitor(samples=None, sample_interval=1):
+    """Return a minimal LinuxPowerMonitor-like object without starting a thread."""
+    from greenprompt.samplerLinux import LinuxPowerMonitor
+    with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=None), \
+         patch("greenprompt.samplerLinux._detect_cpu_clusters", return_value={}), \
+         patch("psutil.cpu_percent", return_value=[10.0] * 20):
+        m = LinuxPowerMonitor.__new__(LinuxPowerMonitor)
+        m.samples = deque(maxlen=600)
+        m.running = False
+        m.sample_interval = sample_interval
+        m.cpu_tdp_w = 23.0
+        m._lock = threading.Lock()
+        m._stop_event = threading.Event()
+        m._cpu_mode = "linear_tdp"
+        m._gpu_available = None
+        m._gpu_unavailable_warned = False
+        m._dmon = None
+        if samples:
+            m.samples.extend(samples)
+        return m
+
+
+def _sample(cpu=5.0, gpu=3.0):
+    return {"cpu_power_w": cpu, "gpu_power_w": gpu, "combined_power_w": cpu + gpu}
+
+
+# ===========================================================================
+# 1. _parse_nvidia_power
+# ===========================================================================
+
+class TestParseNvidiaPower(unittest.TestCase):
+
+    def _p(self, raw):
+        from greenprompt.samplerLinux import _parse_nvidia_power
+        return _parse_nvidia_power(raw)
+
+    def test_normal_float(self):
+        self.assertAlmostEqual(self._p("12.34"), 12.34)
+
+    def test_na_variants(self):
+        for val in ("[N/A]", "N/A", "Unknown Error", "", "  "):
+            self.assertEqual(self._p(val), 0.0, msg=f"expected 0.0 for {val!r}")
+
+    def test_non_numeric(self):
+        self.assertEqual(self._p("watts"), 0.0)
+
+    def test_zero(self):
+        self.assertEqual(self._p("0"), 0.0)
+
+    def test_large_value(self):
+        self.assertAlmostEqual(self._p("999.9"), 999.9)
+
+    def test_negative(self):
+        # negative power is physically wrong but should parse without crash
+        self.assertAlmostEqual(self._p("-1.5"), -1.5)
+
+    def test_whitespace_padded(self):
+        self.assertAlmostEqual(self._p("  7.5  "), 7.5)
+
+
+# ===========================================================================
+# 2. CPU architecture detection
+# ===========================================================================
+
+class TestDetectRaplPath(unittest.TestCase):
+
+    def setUp(self):
+        from greenprompt.samplerLinux import _detect_rapl_path
+        self._fn = _detect_rapl_path
+
+    def test_no_rapl_returns_none(self):
+        with patch("os.path.exists", return_value=False), \
+             patch("glob.glob", return_value=[]):
+            self.assertIsNone(self._fn())
+
+    def test_direct_path_found(self):
+        with patch("os.path.exists", return_value=True):
+            result = self._fn()
+            self.assertIn("energy_uj", result)
+
+    def test_glob_fallback(self):
+        fake = "/sys/class/powercap/intel-rapl:0/intel-rapl:0:0/energy_uj"
+        with patch("os.path.exists", return_value=False), \
+             patch("glob.glob", return_value=[fake]):
+            self.assertEqual(self._fn(), fake)
+
+    def test_multiple_glob_returns_first(self):
+        paths = [
+            "/sys/class/powercap/intel-rapl:0/intel-rapl:0:0/energy_uj",
+            "/sys/class/powercap/intel-rapl:1/intel-rapl:1:0/energy_uj",
+        ]
+        with patch("os.path.exists", return_value=False), \
+             patch("glob.glob", return_value=paths):
+            self.assertEqual(self._fn(), paths[0])
+
+
+class TestDetectCpuClusters(unittest.TestCase):
+
+    def setUp(self):
+        from greenprompt.samplerLinux import _detect_cpu_clusters
+        self._fn = _detect_cpu_clusters
+
+    def _freq(self, max_mhz):
+        f = MagicMock()
+        f.max = float(max_mhz)
+        return f
+
+    def test_heterogeneous_two_clusters(self):
+        freqs = [self._freq(2808)] * 10 + [self._freq(3900)] * 10
+        with patch("psutil.cpu_freq", return_value=freqs):
+            clusters = self._fn()
+        self.assertEqual(set(clusters.keys()), {2808, 3900})
+        self.assertEqual(len(clusters[2808]), 10)
+        self.assertEqual(len(clusters[3900]), 10)
+
+    def test_single_cluster_returns_empty(self):
+        freqs = [self._freq(3200)] * 8
+        with patch("psutil.cpu_freq", return_value=freqs):
+            self.assertEqual(self._fn(), {})
+
+    def test_none_returns_empty(self):
+        with patch("psutil.cpu_freq", return_value=None):
+            self.assertEqual(self._fn(), {})
+
+    def test_empty_list_returns_empty(self):
+        with patch("psutil.cpu_freq", return_value=[]):
+            self.assertEqual(self._fn(), {})
+
+    def test_single_cpu_returns_empty(self):
+        with patch("psutil.cpu_freq", return_value=[self._freq(2400)]):
+            self.assertEqual(self._fn(), {})
+
+    def test_three_clusters(self):
+        freqs = [self._freq(1800)] * 4 + [self._freq(2400)] * 4 + [self._freq(3600)] * 4
+        with patch("psutil.cpu_freq", return_value=freqs):
+            clusters = self._fn()
+        self.assertEqual(len(clusters), 3)
+
+    def test_psutil_exception_returns_empty(self):
+        with patch("psutil.cpu_freq", side_effect=RuntimeError("no freq")):
+            self.assertEqual(self._fn(), {})
+
+
+# ===========================================================================
+# 3. LinuxPowerMonitor construction — arch mode selection
+# ===========================================================================
+
+class TestMonitorModeSelection(unittest.TestCase):
+
+    def _build(self, rapl=None, clusters=None):
+        from greenprompt.samplerLinux import LinuxPowerMonitor
+        with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=rapl), \
+             patch("greenprompt.samplerLinux._detect_cpu_clusters",
+                   return_value=clusters or {}), \
+             patch("psutil.cpu_percent", return_value=[0.0] * 4):
+            return LinuxPowerMonitor()
+
+    def test_rapl_mode_when_rapl_available(self):
+        m = self._build(rapl="/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj")
+        self.assertEqual(m._cpu_mode, "rapl")
+        self.assertTrue(hasattr(m, "_rapl_path"))
+        self.assertIsNone(m._rapl_last_energy)
+
+    def test_biglittle_mode_when_clusters_detected(self):
+        m = self._build(clusters={2808: [0, 1], 3900: [2, 3]})
+        self.assertEqual(m._cpu_mode, "arm_biglittle")
+        self.assertIn(2808, m._clusters)
+
+    def test_linear_tdp_fallback(self):
+        m = self._build(rapl=None, clusters={})
+        self.assertEqual(m._cpu_mode, "linear_tdp")
+
+    def test_rapl_takes_priority_over_biglittle(self):
+        m = self._build(
+            rapl="/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj",
+            clusters={2808: [0], 3900: [1]},
+        )
+        self.assertEqual(m._cpu_mode, "rapl")
+
+
+# ===========================================================================
+# 4. _sample_cpu_rapl — sysfs read edge cases
+# ===========================================================================
+
+class TestSampleCpuRapl(unittest.TestCase):
+
+    def _monitor_rapl(self, rapl_path="/fake/energy_uj"):
+        from greenprompt.samplerLinux import LinuxPowerMonitor
+        with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=rapl_path), \
+             patch("greenprompt.samplerLinux._detect_cpu_clusters", return_value={}), \
+             patch("psutil.cpu_percent", return_value=[0.0] * 4):
+            m = LinuxPowerMonitor()
+        m._rapl_path = rapl_path
+        m._rapl_max_path = rapl_path.replace("energy_uj", "max_energy_range_uj")
+        m._rapl_last_energy = None
+        m._rapl_last_ts = None
+        return m
+
+    def test_first_call_returns_zero(self):
+        m = self._monitor_rapl()
+        with patch("builtins.open", mock_open(read_data="1000000")):
+            result = m._sample_cpu_rapl()
+        self.assertEqual(result, 0.0)
+        self.assertEqual(m._rapl_last_energy, 1000000)
+
+    def test_second_call_returns_watts(self):
+        m = self._monitor_rapl()
+        t0 = time.time()
+        m._rapl_last_energy = 0
+        m._rapl_last_ts = t0 - 1.0  # 1 second ago
+        with patch("builtins.open", mock_open(read_data="1000000")):  # 1 J in 1s = 1W
+            with patch("time.time", return_value=t0):
+                result = m._sample_cpu_rapl()
+        self.assertAlmostEqual(result, 1.0, places=1)
+
+    def test_counter_overflow_handled(self):
+        m = self._monitor_rapl()
+        t0 = time.time()
+        m._rapl_last_energy = 4_000_000_000_000  # near overflow
+        m._rapl_last_ts = t0 - 1.0
+        # New reading wraps to small value
+        MAX = 4_294_967_295_000  # ~2^32 * 1000
+        new_energy = 100_000  # wrapped around
+        expected_delta_uj = new_energy - m._rapl_last_energy + MAX
+        expected_w = (expected_delta_uj / 1_000_000.0) / 1.0
+
+        def fake_open(path, *a, **kw):
+            if "max_energy" in path:
+                return mock_open(read_data=str(MAX))()
+            return mock_open(read_data=str(new_energy))()
+
+        with patch("builtins.open", fake_open), patch("time.time", return_value=t0):
+            result = m._sample_cpu_rapl()
+        self.assertGreater(result, 0.0)
+
+    def test_oserror_returns_zero(self):
+        m = self._monitor_rapl()
+        m._rapl_last_energy = 0
+        m._rapl_last_ts = time.time() - 1.0
+        with patch("builtins.open", side_effect=OSError("no file")):
+            self.assertEqual(m._sample_cpu_rapl(), 0.0)
+
+    def test_bad_int_returns_zero(self):
+        m = self._monitor_rapl()
+        m._rapl_last_energy = 0
+        m._rapl_last_ts = time.time() - 1.0
+        with patch("builtins.open", mock_open(read_data="NOT_AN_INT")):
+            self.assertEqual(m._sample_cpu_rapl(), 0.0)
+
+    def test_zero_elapsed_returns_zero(self):
+        m = self._monitor_rapl()
+        ts = time.time()
+        m._rapl_last_energy = 500_000
+        m._rapl_last_ts = ts
+        with patch("builtins.open", mock_open(read_data="1000000")), \
+             patch("time.time", return_value=ts):  # same timestamp → delta_s == 0
+            self.assertEqual(m._sample_cpu_rapl(), 0.0)
+
+
+# ===========================================================================
+# 5. _sample_cpu_biglittle — cluster model edge cases
+# ===========================================================================
+
+class TestSampleCpuBiglittle(unittest.TestCase):
+
+    def _monitor_biglittle(self, clusters):
+        from greenprompt.samplerLinux import LinuxPowerMonitor
+        with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=None), \
+             patch("greenprompt.samplerLinux._detect_cpu_clusters", return_value=clusters), \
+             patch("psutil.cpu_percent", return_value=[0.0] * 20):
+            m = LinuxPowerMonitor()
+        return m
+
+    def test_idle_system_near_idle_power(self):
+        clusters = {2808: list(range(10)), 3900: list(range(10, 20))}
+        m = self._monitor_biglittle(clusters)
+        cpu_pcts = [0.0] * 20
+        sysfs_freq = "2808000"  # kHz = 2808 MHz
+
+        with patch("psutil.cpu_percent", return_value=cpu_pcts), \
+             patch("builtins.open", mock_open(read_data=sysfs_freq)):
+            result = m._sample_cpu_biglittle()
+        # At 0% util, freq_ratio=1, result = idle_w for each cluster
+        expected = 0.5 + 1.0  # A725 idle + X925 idle
+        self.assertAlmostEqual(result, expected, delta=0.5)
+
+    def test_full_load_bounded_by_tdp(self):
+        clusters = {2808: [0, 1], 3900: [2, 3]}
+        m = self._monitor_biglittle(clusters)
+        cpu_pcts = [100.0] * 4
+
+        with patch("psutil.cpu_percent", return_value=cpu_pcts), \
+             patch("builtins.open", mock_open(read_data="3900000")):
+            result = m._sample_cpu_biglittle()
+        # Should not exceed sum of TDP values
+        max_expected = 8.0 + 23.0
+        self.assertLessEqual(result, max_expected * 1.1)
+
+    def test_missing_sysfs_falls_back_to_max_freq(self):
+        clusters = {2808: [0, 1], 3900: [2, 3]}
+        m = self._monitor_biglittle(clusters)
+        cpu_pcts = [50.0] * 4
+
+        with patch("psutil.cpu_percent", return_value=cpu_pcts), \
+             patch("builtins.open", side_effect=OSError("no sysfs")):
+            result = m._sample_cpu_biglittle()
+        # Should still return a positive number using max freq as fallback
+        self.assertGreater(result, 0.0)
+
+    def test_unknown_cluster_freq_uses_tdp_fraction(self):
+        # A cluster with max_mhz not in _CLUSTER_TDP should use cpu_tdp_w / n_clusters
+        clusters = {9999: [0, 1]}
+        m = self._monitor_biglittle(clusters)
+        m.cpu_tdp_w = 20.0
+        cpu_pcts = [50.0] * 2
+
+        with patch("psutil.cpu_percent", return_value=cpu_pcts), \
+             patch("builtins.open", mock_open(read_data="9999000")):
+            result = m._sample_cpu_biglittle()
+        self.assertGreater(result, 0.0)
+
+    def test_cpu_pcts_shorter_than_cluster_indices(self):
+        # Simulate psutil returning fewer entries than cluster claims
+        clusters = {3900: [0, 1, 2, 3, 4]}
+        m = self._monitor_biglittle(clusters)
+        cpu_pcts = [50.0, 50.0]  # only 2 entries for 5 cpu indices
+
+        with patch("psutil.cpu_percent", return_value=cpu_pcts), \
+             patch("builtins.open", mock_open(read_data="3900000")):
+            result = m._sample_cpu_biglittle()  # must not crash
+        self.assertGreaterEqual(result, 0.0)
+
+    def test_freq_ratio_capped_at_one(self):
+        # If scaling_cur_freq > max_freq (shouldn't happen but defend against it)
+        clusters = {2808: [0]}
+        m = self._monitor_biglittle(clusters)
+        cpu_pcts = [100.0]
+        # Return a freq higher than max
+        with patch("psutil.cpu_percent", return_value=cpu_pcts), \
+             patch("builtins.open", mock_open(read_data="9999999")):
+            result = m._sample_cpu_biglittle()
+        # power should be capped at TDP, not exceed it due to freq_ratio > 1
+        self.assertLessEqual(result, 8.0 * 1.1)
+
+
+# ===========================================================================
+# 6. NvidiaDmonReader edge cases
+# ===========================================================================
+
+class TestNvidiaDmonReader(unittest.TestCase):
+
+    def test_unavailable_sets_failed(self):
+        from greenprompt.samplerLinux import NvidiaDmonReader
+        with patch("subprocess.Popen", side_effect=FileNotFoundError):
+            r = NvidiaDmonReader()
+        self.assertTrue(r._failed)
+        self.assertEqual(r.get_power(), 0.0)
+
+    def test_oserror_sets_failed(self):
+        from greenprompt.samplerLinux import NvidiaDmonReader
+        with patch("subprocess.Popen", side_effect=OSError("perm denied")):
+            r = NvidiaDmonReader()
+        self.assertTrue(r._failed)
+
+    def test_header_lines_skipped(self):
+        from greenprompt.samplerLinux import NvidiaDmonReader
+        lines = ["# gpu   pwr\n", "#  Idx   W\n", "   0   15\n"]
+        proc = MagicMock()
+        proc.stdout = iter(lines)
+        with patch("subprocess.Popen", return_value=proc):
+            r = NvidiaDmonReader()
+            time.sleep(0.1)
+        self.assertAlmostEqual(r.get_power(), 15.0)
+
+    def test_garbled_line_ignored(self):
+        from greenprompt.samplerLinux import NvidiaDmonReader
+        lines = ["garbage output\n", "   0  NOTANUMBER\n", "   0   7\n"]
+        proc = MagicMock()
+        proc.stdout = iter(lines)
+        with patch("subprocess.Popen", return_value=proc):
+            r = NvidiaDmonReader()
+            time.sleep(0.1)
+        self.assertAlmostEqual(r.get_power(), 7.0)
+
+    def test_empty_lines_ignored(self):
+        from greenprompt.samplerLinux import NvidiaDmonReader
+        lines = ["\n", "   \n", "   0   9\n"]
+        proc = MagicMock()
+        proc.stdout = iter(lines)
+        with patch("subprocess.Popen", return_value=proc):
+            r = NvidiaDmonReader()
+            time.sleep(0.1)
+        self.assertAlmostEqual(r.get_power(), 9.0)
+
+    def test_stop_terminates_process(self):
+        from greenprompt.samplerLinux import NvidiaDmonReader
+        proc = MagicMock()
+        proc.stdout = iter([])
+        with patch("subprocess.Popen", return_value=proc):
+            r = NvidiaDmonReader()
+        r.stop()
+        proc.terminate.assert_called_once()
+        proc.wait.assert_called_once()
+
+    def test_concurrent_reads_thread_safe(self):
+        from greenprompt.samplerLinux import NvidiaDmonReader
+        proc = MagicMock()
+        proc.stdout = iter([f"   0   {i}\n" for i in range(100)])
+        with patch("subprocess.Popen", return_value=proc):
+            r = NvidiaDmonReader()
+        errors = []
+        def reader():
+            for _ in range(200):
+                try:
+                    r.get_power()
+                except Exception as e:
+                    errors.append(e)
+        threads = [threading.Thread(target=reader) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+
+
+# ===========================================================================
+# 7. LinuxPowerMonitor lifecycle
+# ===========================================================================
+
+class TestMonitorLifecycle(unittest.TestCase):
+
+    def _build_nogpu(self):
+        from greenprompt.samplerLinux import LinuxPowerMonitor
+        with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=None), \
+             patch("greenprompt.samplerLinux._detect_cpu_clusters", return_value={}), \
+             patch("psutil.cpu_percent", return_value=[10.0] * 4):
+            m = LinuxPowerMonitor()
+        return m
+
+    def test_start_stop(self):
+        m = self._build_nogpu()
+        with patch.object(m, "_check_gpu", return_value=False), \
+             patch("greenprompt.samplerLinux.NvidiaDmonReader") as MockDmon:
+            MockDmon.return_value._failed = True
+            m.start()
+            time.sleep(0.5)
+            m.stop()
+        self.assertFalse(m.running)
+
+    def test_rapid_start_stop_10x(self):
+        """Monitor must survive 10 rapid start/stop cycles without deadlock."""
+        for _ in range(10):
+            from greenprompt.samplerLinux import LinuxPowerMonitor
+            with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=None), \
+                 patch("greenprompt.samplerLinux._detect_cpu_clusters", return_value={}), \
+                 patch("psutil.cpu_percent", return_value=[5.0] * 4):
+                m = LinuxPowerMonitor()
+            with patch.object(m, "_check_gpu", return_value=False), \
+                 patch("greenprompt.samplerLinux.NvidiaDmonReader") as MockDmon:
+                MockDmon.return_value._failed = True
+                m.start()
+                time.sleep(0.05)
+                m.stop()
+            self.assertFalse(m.running)
+
+    def test_samples_accumulate_over_time(self):
+        m = self._build_nogpu()
+        with patch.object(m, "_check_gpu", return_value=False), \
+             patch("greenprompt.samplerLinux.NvidiaDmonReader") as MockDmon:
+            MockDmon.return_value._failed = True
+            m.start()
+            time.sleep(3.5)
+            m.stop()
+        self.assertGreaterEqual(len(m.samples), 3)
+
+    def test_deque_rotates_at_window_size(self):
+        from greenprompt.samplerLinux import LinuxPowerMonitor
+        with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=None), \
+             patch("greenprompt.samplerLinux._detect_cpu_clusters", return_value={}), \
+             patch("psutil.cpu_percent", return_value=[5.0] * 4):
+            m = LinuxPowerMonitor(window_size=5)
+        # Manually fill beyond window
+        for i in range(10):
+            m.samples.append((time.time() + i, _sample()))
+        self.assertEqual(len(m.samples), 5)
+
+    def test_sample_once_returns_dict(self):
+        m = self._build_nogpu()
+        m._dmon = None
+        # linear_tdp mode: cpu_percent(interval=None) without percpu → scalar
+        def _cpu_pct(*args, **kwargs):
+            return [20.0] * 4 if kwargs.get("percpu") else 20.0
+        with patch.object(m, "_check_gpu", return_value=False), \
+             patch("psutil.cpu_percent", side_effect=_cpu_pct):
+            result = m.sample_once()
+        self.assertIsNotNone(result)
+        self.assertIn("cpu_power_w", result)
+        self.assertIn("gpu_power_w", result)
+        self.assertIn("combined_power_w", result)
+        self.assertGreaterEqual(result["cpu_power_w"], 0.0)
+
+    def test_sample_once_exception_returns_none(self):
+        m = self._build_nogpu()
+        with patch("psutil.cpu_percent", side_effect=RuntimeError("psutil broken")):
+            result = m.sample_once()
+        self.assertIsNone(result)
+
+    def test_get_range_average_empty_returns_none(self):
+        m = self._build_nogpu()
+        result = m.get_range_average(time.time() - 60, time.time())
+        self.assertIsNone(result)
+
+    def test_get_range_average_correct(self):
+        m = self._build_nogpu()
+        now = time.time()
+        m.samples.append((now - 2, _sample(cpu=4.0, gpu=2.0)))
+        m.samples.append((now - 1, _sample(cpu=6.0, gpu=4.0)))
+        avg = m.get_range_average(now - 5, now)
+        self.assertAlmostEqual(avg, 8.0)  # (6+6+10+10)/2 = 8
+
+    def test_thread_safety_concurrent_append_and_read(self):
+        """Concurrent appends and get_range_average must never raise."""
+        m = self._build_nogpu()
+        errors = []
+        stop = threading.Event()
+
+        def writer():
+            while not stop.is_set():
+                with m._lock:
+                    m.samples.append((time.time(), _sample()))
+                time.sleep(0.001)
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    m.get_range_average(time.time() - 5, time.time())
+                except Exception as e:
+                    errors.append(e)
+                time.sleep(0.001)
+
+        threads = [threading.Thread(target=writer)] + \
+                  [threading.Thread(target=reader) for _ in range(5)]
+        for t in threads:
+            t.start()
+        time.sleep(1.0)
+        stop.set()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+
+    def test_stop_latency_under_500ms(self):
+        m = self._build_nogpu()
+        with patch.object(m, "_check_gpu", return_value=False), \
+             patch("greenprompt.samplerLinux.NvidiaDmonReader") as MockDmon:
+            MockDmon.return_value._failed = True
+            m.start()
+            time.sleep(0.5)
+            t0 = time.time()
+            m.stop()
+            elapsed_ms = (time.time() - t0) * 1000
+        self.assertLess(elapsed_ms, 500, f"stop() took {elapsed_ms:.0f}ms — too slow")
+
+
+# ===========================================================================
+# 8. measure_power_linux edge cases
+# ===========================================================================
+
+class TestMeasurePowerLinux(unittest.TestCase):
+
+    def _call(self, start, end, monitor):
+        from greenprompt.sysUsage import measure_power_linux
+        return measure_power_linux(start, end, monitor)
+
+    def test_none_monitor_returns_zeros(self):
+        result = self._call(0, 1, None)
+        self.assertEqual(result["energy_wh"], 0.0)
+        self.assertEqual(result["cpu_power_w"], 0.0)
+
+    def test_empty_samples_no_neighbors_returns_zeros(self):
+        m = _make_monitor(samples=[])
+        result = self._call(time.time() - 1, time.time(), m)
+        self.assertEqual(result["energy_wh"], 0.0)
+
+    def test_normal_samples_in_window(self):
+        now = time.time()
+        samples = [
+            (now - 0.8, _sample(cpu=4.0, gpu=2.0)),
+            (now - 0.4, _sample(cpu=6.0, gpu=2.0)),
+        ]
+        m = _make_monitor(samples=samples)
+        result = self._call(now - 1.0, now, m)
+        self.assertGreater(result["energy_wh"], 0.0)
+        self.assertAlmostEqual(result["cpu_power_w"], 5.0)
+        self.assertAlmostEqual(result["gpu_power_w"], 2.0)
+
+    def test_short_prompt_interpolates_from_neighbors(self):
+        now = time.time()
+        # Samples right before and after a 0.1s prompt window
+        samples = [
+            (now - 0.8, _sample(cpu=4.0, gpu=2.0)),  # before
+            (now + 0.5, _sample(cpu=6.0, gpu=2.0)),  # after
+        ]
+        m = _make_monitor(samples=samples, sample_interval=1)
+        start = now - 0.05
+        end = now + 0.05
+        result = self._call(start, end, m)
+        self.assertGreater(result["energy_wh"], 0.0)
+        self.assertTrue(result.get("extrapolated", False))
+
+    def test_short_prompt_no_neighbors_returns_zeros(self):
+        now = time.time()
+        # Neighbors too far away (> 2 * sample_interval)
+        samples = [
+            (now - 10.0, _sample()),   # too old
+            (now + 10.0, _sample()),   # too far in future
+        ]
+        m = _make_monitor(samples=samples, sample_interval=1)
+        result = self._call(now - 0.05, now + 0.05, m)
+        self.assertEqual(result["energy_wh"], 0.0)
+        self.assertFalse(result.get("extrapolated", False))
+
+    def test_zero_duration_prompt(self):
+        now = time.time()
+        m = _make_monitor(samples=[(now - 0.5, _sample(cpu=5.0, gpu=3.0))])
+        result = self._call(now, now, m)
+        # energy = power * 0s = 0
+        self.assertEqual(result["energy_wh"], 0.0)
+        self.assertEqual(result["duration_sec"], 0.0)
+
+    def test_start_equals_end(self):
+        now = time.time()
+        m = _make_monitor(samples=[(now - 0.5, _sample())])
+        result = self._call(now, now, m)
+        self.assertIn("cpu_power_w", result)
+
+    def test_baseline_computed_from_60s_window(self):
+        now = time.time()
+        samples = (
+            [(now - 70 + i, _sample(cpu=2.0, gpu=1.0)) for i in range(10)]  # before baseline
+            + [(now - 50 + i, _sample(cpu=8.0, gpu=4.0)) for i in range(10)]  # in baseline
+            + [(now - 0.5, _sample(cpu=10.0, gpu=5.0))]  # in prompt
+        )
+        m = _make_monitor(samples=samples)
+        result = self._call(now - 0.2, now, m)
+        self.assertAlmostEqual(result["baseline_power_w"], 12.0, delta=0.5)
+
+    def test_no_baseline_samples_returns_zero_baseline(self):
+        now = time.time()
+        # Sample is inside the prompt window [now-0.2, now] only.
+        # Baseline window is [now-60.2, now-0.2] — no samples there.
+        m = _make_monitor(samples=[(now - 0.1, _sample(cpu=5.0, gpu=3.0))])
+        result = self._call(now - 0.2, now, m)
+        self.assertEqual(result["baseline_power_w"], 0.0)
+
+    def test_monitor_without_lock_attribute_still_works(self):
+        # Older monitor instances may lack _lock
+        m = _make_monitor(samples=[(time.time() - 0.5, _sample())])
+        del m._lock  # simulate old instance
+        from greenprompt.sysUsage import measure_power_linux
+        now = time.time()
+        result = measure_power_linux(now - 0.3, now, m)
+        self.assertIn("cpu_power_w", result)
+
+    def test_only_after_neighbor_used(self):
+        now = time.time()
+        samples = [(now + 0.5, _sample(cpu=5.0, gpu=2.0))]  # only after
+        m = _make_monitor(samples=samples, sample_interval=1)
+        result = self._call(now - 0.05, now + 0.05, m)
+        self.assertTrue(result.get("extrapolated", False))
+        self.assertAlmostEqual(result["cpu_power_w"], 5.0)
+
+    def test_only_before_neighbor_used(self):
+        now = time.time()
+        samples = [(now - 0.5, _sample(cpu=7.0, gpu=3.0))]  # only before
+        m = _make_monitor(samples=samples, sample_interval=1)
+        result = self._call(now - 0.05, now + 0.05, m)
+        self.assertTrue(result.get("extrapolated", False))
+        self.assertAlmostEqual(result["cpu_power_w"], 7.0)
+
+
+# ===========================================================================
+# 9. Architecture simulation — Intel RAPL end-to-end sampling
+# ===========================================================================
+
+class TestRaplEndToEnd(unittest.TestCase):
+
+    def test_rapl_sampling_produces_nonzero_after_first_call(self):
+        from greenprompt.samplerLinux import LinuxPowerMonitor
+        fake_rapl = "/tmp/fake_energy_uj"
+        with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=fake_rapl), \
+             patch("greenprompt.samplerLinux._detect_cpu_clusters", return_value={}), \
+             patch("psutil.cpu_percent", return_value=[10.0] * 4):
+            m = LinuxPowerMonitor()
+
+        energy_values = iter([1_000_000, 3_000_000])  # 2J in 1s = 2W
+
+        def fake_open(path, *a, **kw):
+            if "max_energy" in path:
+                return mock_open(read_data="4294967295000")()
+            return mock_open(read_data=str(next(energy_values)))()
+
+        t0 = time.time()
+        with patch("builtins.open", fake_open), patch("time.time", return_value=t0):
+            first = m._sample_cpu_rapl()  # sets baseline
+
+        with patch("builtins.open", fake_open), \
+             patch("time.time", return_value=t0 + 1.0):
+            second = m._sample_cpu_rapl()
+
+        self.assertEqual(first, 0.0)
+        self.assertAlmostEqual(second, 2.0, places=0)
+
+
+# ===========================================================================
+# 10. API endpoint edge cases
+# ===========================================================================
+
+class TestApiEdgeCases(unittest.TestCase):
+
+    def setUp(self):
+        from greenprompt.api import app
+        app.config["TESTING"] = True
+        self.client = app.test_client()
+
+    def test_empty_prompt_returns_400(self):
+        resp = self.client.post(
+            "/api/prompt",
+            json={"prompt": "", "model": "llama3.2:latest"},
+        )
+        self.assertEqual(resp.status_code, 400)
+        data = resp.get_json()
+        self.assertIn("error", data)
+
+    def test_missing_json_body_returns_400(self):
+        # Non-JSON content-type: get_json(silent=True) returns None → {} → prompt="" → 400
+        resp = self.client.post("/api/prompt", data="not json",
+                                content_type="text/plain")
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("error", resp.get_json())
+
+    def test_usage_all_returns_list(self):
+        resp = self.client.get("/api/usage/all")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsInstance(resp.get_json(), list)
+
+    def test_usage_by_model_returns_list(self):
+        resp = self.client.get("/api/usage/model/llama3.2:latest")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsInstance(resp.get_json(), list)
+
+    def test_usage_timeframe_missing_params_returns_400(self):
+        resp = self.client.get("/api/usage/timeframe")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_usage_timeframe_missing_end_returns_400(self):
+        resp = self.client.get("/api/usage/timeframe?start=2026-01-01T00:00:00")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_dashboard_returns_html(self):
+        resp = self.client.get("/dashboard")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"GreenPrompt", resp.data)
+
+    def test_bad_model_returns_400(self):
+        with patch("greenprompt.api.run_prompt",
+                   side_effect=RuntimeError("model 'badmodel' not found")):
+            resp = self.client.post(
+                "/api/prompt",
+                json={"prompt": "hello", "model": "badmodel"},
+            )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("error", resp.get_json())
+
+    def test_internal_exception_returns_500(self):
+        with patch("greenprompt.api.run_prompt",
+                   side_effect=Exception("unexpected crash")):
+            resp = self.client.post(
+                "/api/prompt",
+                json={"prompt": "hello", "model": "llama3.2:latest"},
+            )
+        self.assertEqual(resp.status_code, 500)
+        data = resp.get_json()
+        self.assertIn("error", data)
+
+    def test_concurrent_usage_all_requests(self):
+        results = []
+        errors = []
+        def hit():
+            try:
+                r = self.client.get("/api/usage/all")
+                results.append(r.status_code)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=hit) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+        self.assertTrue(all(s == 200 for s in results))
+
+
+# ===========================================================================
+# 11. Stress: high-frequency sample_once calls (no crashes, no lock contention)
+# ===========================================================================
+
+class TestHighFrequencySampling(unittest.TestCase):
+
+    def test_1000_sample_once_calls_no_crash(self):
+        from greenprompt.samplerLinux import LinuxPowerMonitor
+        def _cpu_pct(*args, **kwargs):
+            return [15.0] * 4 if kwargs.get("percpu") else 15.0
+        with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=None), \
+             patch("greenprompt.samplerLinux._detect_cpu_clusters", return_value={}), \
+             patch("psutil.cpu_percent", side_effect=_cpu_pct):
+            m = LinuxPowerMonitor()
+        m._dmon = None
+        errors = []
+        with patch.object(m, "_check_gpu", return_value=False), \
+             patch("psutil.cpu_percent", side_effect=_cpu_pct):
+            for _ in range(1000):
+                try:
+                    result = m.sample_once()
+                    if result is None:
+                        errors.append("None result")
+                except Exception as e:
+                    errors.append(str(e))
+        self.assertEqual(errors, [])
+
+    def test_concurrent_sample_once_and_get_range(self):
+        from greenprompt.samplerLinux import LinuxPowerMonitor
+        with patch("greenprompt.samplerLinux._detect_rapl_path", return_value=None), \
+             patch("greenprompt.samplerLinux._detect_cpu_clusters", return_value={}), \
+             patch("psutil.cpu_percent", return_value=[15.0] * 4):
+            m = LinuxPowerMonitor()
+        m._dmon = None
+        errors = []
+        stop = threading.Event()
+
+        def sampler():
+            while not stop.is_set():
+                with patch.object(m, "_check_gpu", return_value=False), \
+                     patch("psutil.cpu_percent", return_value=[15.0] * 4):
+                    s = m.sample_once()
+                if s:
+                    with m._lock:
+                        m.samples.append((time.time(), s))
+                time.sleep(0.001)
+
+        def ranger():
+            while not stop.is_set():
+                try:
+                    m.get_range_average(time.time() - 5, time.time())
+                except Exception as e:
+                    errors.append(e)
+                time.sleep(0.001)
+
+        threads = [threading.Thread(target=sampler)] + \
+                  [threading.Thread(target=ranger) for _ in range(3)]
+        for t in threads:
+            t.start()
+        time.sleep(1.5)
+        stop.set()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Full Linux power tracking implementation with improved CPU architecture coverage, GPU efficiency, and production-hardening.

### What's in this PR

**Linux Power Monitoring (`samplerLinux.py` — full rewrite)**
- Auto-detects CPU measurement strategy at startup (priority order):
  1. **RAPL** (Intel/AMD) — reads `energy_uj` counter delta from sysfs; actual watts, no estimation
  2. **ARM big.LITTLE** — per-cluster frequency-squared model (`idle + util × (tdp−idle) × (freq/max_freq)²`); detects heterogeneous clusters via `psutil.cpu_freq(percpu=True)`
  3. **linear_tdp** — fallback: `cpu_percent / 100 × cpu_tdp_w`
- `NvidiaDmonReader`: one long-running `nvidia-smi dmon -s p -d 1` process instead of forking nvidia-smi every second (3600 → 1 forks/hour)
- `threading.Event` replaces `time.sleep()` → `stop()` returns in ~100–300ms (was up to 1s)
- `threading.Lock` on `self.samples` deque for safe cross-thread reads
- `_CLUSTER_TDP` table for A725 E-cores (8W) and X925 P-cores (23W)

**Power Measurement Dispatch (`sysUsage.py`)**
- `measure_power_linux()` takes a single lock-protected snapshot instead of two separate deque iterations
- Short-prompt interpolation: when prompt window < 1s contains no samples, uses nearest neighbors (within `2 × sample_interval`) as proxy; returns `"extrapolated": True`

**Setup (`setup.py` + `constants.py`)**
- TDP table corrected: Cortex-X925 23W (was 40W), Cortex-A725 8W added
- RAPL auto-detection writes `CPU_POWER_SOURCE = 'rapl'` or `'estimated'` to constants
- macOS only: `configure_powermetrics_sudoers()` writes `/etc/sudoers.d/greenprompt` for passwordless powermetrics after `sudo greenprompt setup`

**CLI + API hardening**
- Removed all sudo requirements — no `greenprompt` command needs root on Linux; macOS needs it once for `setup` to configure sudoers
- `--port` flag on `prompt` and `dashboard` subcommands (default 5000)
- Default model changed to `llama3.2:latest` (was `llama2` which is not installed)
- `api.py` wraps `run_prompt()` in try/except → clean JSON errors instead of empty 500 body
- `cli.py` splits `ConnectionError` with actionable "start server first" message
- `dashboard` command uses `webbrowser.open()` (cross-platform, was macOS-only `open`)

### Test results (Linux aarch64, Cortex-X925/A725, NVIDIA GB10 Blackwell)

| Area | Result |
|------|--------|
| CPU mode detected | `arm_biglittle` ✅ |
| RAPL (should be None on ARM) | `None` ✅ |
| nvidia-smi dmon process count | 1 process ✅ |
| Sample values | `cpu=1.73W, gpu=10.0W` ✅ |
| stop() latency | 283ms ✅ |
| Short prompt energy (0.34s) | `0.00156 Wh` (non-zero via interpolation) ✅ |
| Baseline power reported | `11.9W` ✅ |
| All CLI subcommands | Pass (29/29 checks) ✅ |
| All API endpoints | Pass ✅ |
| Bad model error | Clean JSON error ✅ |
| Connection refused error | Actionable message ✅ |
| No sudo on Linux | Confirmed ✅ |

### No new dependencies
All improvements use stdlib (`threading`, `glob`, `os`) and already-required packages (`psutil`, `subprocess`).