### PR TITLE
ci(release): harden PyPI publishing with verification gates and OIDC

### DIFF
--- a/.claude/commands/gp-release.md
+++ b/.claude/commands/gp-release.md
@@ -1,50 +1,80 @@
-Prepare a new GreenPrompt PyPI release.
+Prepare and cut a GreenPrompt release.
 
-Current version is in `pyproject.toml` under `[tool.poetry] version`.
-PyPI package: https://pypi.org/project/greenprompt/
+Publishing is automated. `.github/workflows/publish.yaml` triggers on any `v*.*.*` tag and runs: verify (lint, 76 tests, version guards) → build (`poetry build`, `twine check --strict`, wheel install smoke test) → publish to PyPI via Trusted Publishing (OIDC, no API token) → create a GitHub Release with the artifacts attached.
 
-Task: $ARGUMENTS (e.g., "bump to 0.2.0", "patch release", "check release readiness")
+Your job is to get the repository ready and push the tag. Do NOT run `poetry publish` by hand — that bypasses every guard below.
 
-Steps:
+Task: $ARGUMENTS (e.g. "bump to 0.2.0", "patch release", "check release readiness")
 
-1. Read the current version:
-   ```bash
-   grep '^version' greenprompt/greenprompt/pyproject.toml
-   ```
+## 1. Check readiness
 
-2. Run the linter and formatter to ensure code is clean:
-   ```bash
-   cd greenprompt/greenprompt && poetry run ruff check .
-   cd greenprompt/greenprompt && poetry run ruff fmt --check .
-   ```
+```bash
+# Current version
+grep '^version' pyproject.toml
 
-3. Check for known bugs that should be fixed before release. Read these files and verify:
-   - `api.py` line 2: `from analytics import` → should be `from greenprompt.analytics import`
-   - `api.py` line 130: proxy URL `/ollama/api/` → should be `/api/`
-   - `core.py` line 73-141: `gpu_usage` may be undefined if `has_gpu()` returns False
-   - `analytics.py` lines 96-98: `start_time`/`end_time` params are overwritten with None
-   - `cli.py` lines 199-209: `score` command redundantly re-parses args
-   Report which bugs are still present.
+# What is already on PyPI (a published version can NEVER be reused)
+curl -s https://pypi.org/pypi/greenprompt/json | python3 -c "import json,sys; print(sorted(json.load(sys.stdin)['releases']))"
 
-4. Verify the package builds cleanly:
-   ```bash
-   cd greenprompt/greenprompt && poetry build
-   ```
-   Check `dist/` for the generated `.whl` and `.tar.gz`.
+# Working tree must be clean and on main
+git status --short && git branch --show-current
+```
 
-5. If bumping the version, update `pyproject.toml`:
-   ```bash
-   cd greenprompt/greenprompt && poetry version <new-version>
-   # or edit manually
-   ```
+Run the same gates CI will run, so failures surface locally instead of mid-release:
 
-6. Generate a release checklist:
-   - [ ] Version bumped in pyproject.toml
-   - [ ] Ruff lint passes
-   - [ ] Known bugs addressed (or documented as known issues)
-   - [ ] README reflects new features/changes
-   - [ ] `poetry build` succeeds
-   - [ ] Test install: `pip install dist/*.whl` and run `greenprompt --help`
-   - [ ] Publish: `poetry publish` (requires PyPI credentials)
+```bash
+ruff check .
+python -m unittest discover -s tests -t .
+poetry build && python -m twine check --strict dist/*
+```
 
-Do NOT publish to PyPI without explicit confirmation from the user.
+## 2. Choose the version
+
+Semver against the changes since the last tag (`git log $(git describe --tags --abbrev=0)..HEAD --oneline`):
+
+- **patch** — bug fixes only
+- **minor** — new features, new platform support, backwards-compatible changes
+- **major** — breaking changes to the CLI, REST API, or database schema
+
+The version in `pyproject.toml` and the tag MUST agree; the workflow hard-fails on a mismatch, and it also refuses to republish a version that already exists on PyPI.
+
+## 3. Cut it
+
+```bash
+poetry version minor          # or major / patch / an explicit 0.2.0
+git commit -am "chore(release): $(grep '^version' pyproject.toml | cut -d'"' -f2)"
+git push
+git tag "v$(grep '^version' pyproject.toml | cut -d'"' -f2)"
+git push --tags
+```
+
+Then watch it:
+
+```bash
+gh run watch
+```
+
+## 4. Rehearse without publishing
+
+To exercise the full pipeline (lint, tests, build, metadata check) with the upload skipped:
+
+```bash
+gh workflow run publish.yaml -f dry_run=true
+gh run watch
+```
+
+## Release checklist
+
+- [ ] Working tree clean, on `main`, up to date with origin
+- [ ] `ruff check .` passes
+- [ ] Full test suite passes
+- [ ] Version bumped in `pyproject.toml` and not already on PyPI
+- [ ] README and `docs/` reflect any behaviour changes in this release
+- [ ] `poetry build` + `twine check --strict` pass locally
+- [ ] Tag matches the `pyproject.toml` version exactly, prefixed with `v`
+
+## Notes
+
+- **Trusted Publishing must be configured once** at https://pypi.org/manage/project/greenprompt/settings/publishing/ with owner `uday1201`, repository `greenprompt`, workflow `publish.yaml`, environment `pypi`. Without it the publish step fails to authenticate.
+- The `pypi` GitHub environment is where you add required reviewers if you want a human approval gate before any upload.
+- Never delete and re-push a tag that has already published — PyPI will reject the duplicate version. Bump the patch version instead.
+- Do not publish to PyPI without explicit confirmation from the user.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,50 +1,216 @@
 name: Publish Python Package to PyPI
 
+# Releasing is a deliberate act: push a version tag and this ships it.
+#
+#   poetry version minor          # or major / patch / 0.2.0
+#   git commit -am "chore(release): 0.2.0"
+#   git tag v0.2.0
+#   git push && git push --tags
+#
+# The tag must match the version in pyproject.toml, and that version must not
+# already exist on PyPI — both are checked before anything is uploaded, because
+# a PyPI version number can never be reused once published.
+#
+# Use the workflow_dispatch trigger with dry_run enabled to rehearse the whole
+# pipeline (lint, tests, build, metadata check) without publishing.
+#
+# Authentication is PyPI Trusted Publishing (OIDC) — there is no API token.
+# One-time setup at
+# https://pypi.org/manage/project/greenprompt/settings/publishing/ :
+#   Owner: uday1201 | Repository: greenprompt
+#   Workflow: publish.yaml | Environment: pypi
+
 on:
   push:
     tags:
-      - 'v*.*.*'  # Trigger on version tags like v1.2.3
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build and verify only — do not publish to PyPI'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+# Never cancel a release mid-flight.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PACKAGE_NAME: greenprompt
 
 jobs:
-  publish:
+  verify:
+    name: Verify
     runs-on: ubuntu-latest
-
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
+          cache: pip
 
-      - name: Install Poetry
+      - name: Resolve and validate version
+        id: version
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          set -euo pipefail
+          VERSION="$(python -c '
+          import tomllib, pathlib
+          data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          print(data["tool"]["poetry"]["version"])
+          ')"
+          echo "pyproject version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Cache Poetry dependencies
-        uses: actions/cache@v3
+          # On a tag push the tag must agree with pyproject.toml, otherwise the
+          # git history and the published artifact disagree about what shipped.
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME#v}"
+            if [ "$TAG" != "$VERSION" ]; then
+              echo "::error::Tag v$TAG does not match pyproject.toml version $VERSION."
+              echo "::error::Run 'poetry version $TAG' and commit, or retag as v$VERSION."
+              exit 1
+            fi
+            echo "Tag v$TAG matches pyproject.toml."
+          fi
+
+      - name: Check the version is not already on PyPI
+        run: |
+          set -euo pipefail
+          # Fail here with an actionable message rather than letting the upload
+          # die on an opaque "File already exists" 400 at the very last step.
+          if curl -sSf "https://pypi.org/pypi/${PACKAGE_NAME}/json" -o pypi.json; then
+            if python -c '
+          import json, os, sys
+          releases = json.load(open("pypi.json"))["releases"]
+          sys.exit(0 if os.environ["VERSION"] in releases else 1)
+          ' ; then
+              echo "::error::${PACKAGE_NAME} ${VERSION} is already published on PyPI and cannot be replaced."
+              echo "::error::Bump the version with 'poetry version patch' and tag again."
+              exit 1
+            fi
+            echo "${VERSION} is not yet on PyPI."
+          else
+            echo "Package not found on PyPI — treating as a first release."
+          fi
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Install Ruff
+        run: pip install 'ruff==0.11.11'
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Pre-download NLTK data
+        run: |
+          python - <<'PY'
+          import nltk
+          for r in ("punkt", "punkt_tab", "averaged_perceptron_tagger",
+                    "averaged_perceptron_tagger_eng", "wordnet", "stopwords"):
+              nltk.download(r, quiet=True)
+          PY
+
+      - name: Run tests
+        run: |
+          mkdir -p "$RUNNER_TEMP/run"
+          cd "$RUNNER_TEMP/run"
+          python -m unittest discover -s "$GITHUB_WORKSPACE/tests" -t "$GITHUB_WORKSPACE"
+
+  build:
+    name: Build distributions
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-
+          python-version: '3.11'
+          cache: pip
 
-      - name: Install dependencies
-        run: poetry install --no-interaction --no-ansi
+      - name: Install Poetry and Twine
+        run: pip install poetry twine
 
-      - name: Lint with Ruff
-        run: |
-          poetry add ruff
-          poetry run ruff check .
-      - name: Clean dist directory
-        run: rm -rf dist/
-      - name: Build distributions
+      - name: Build
         run: poetry build --no-interaction --no-ansi
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Check distribution metadata
+        run: twine check --strict dist/*
+
+      - name: Verify the wheel installs and runs
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/verify
+          /tmp/verify/bin/pip install --quiet dist/*.whl
+          cd "$RUNNER_TEMP"
+          /tmp/verify/bin/greenprompt --help
+          /tmp/verify/bin/greenp score "Summarize this. Format: bullet points."
+
+      - name: List artifacts
+        run: ls -la dist/
+
+      - uses: actions/upload-artifact@v4
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: [verify, build]
+    # Skipped for a dry run; always runs for a real tag push.
+    if: github.event_name == 'push' || inputs.dry_run == false
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No user/password: identity is proven via OIDC.
+
+  github-release:
+    name: Create GitHub Release
+    needs: [verify, publish]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create release with autogenerated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" \
+            --title "v$VERSION" \
+            --generate-notes \
+            --verify-tag \
+            dist/*


### PR DESCRIPTION
Automates and gates releasing to PyPI. Split out of #16 — it was pushed to that branch just after it merged, so it needs its own PR. Depends on #16 (now on `main`) because the new `verify` job runs the test suite.

## The gap

`publish.yaml` published straight from a tag with no gate: it never ran the tests, never checked that the tag agreed with `pyproject.toml`, and never checked whether the version was already on PyPI. It also ran `poetry add ruff` (mutating `pyproject.toml` mid-release) and authenticated with a long-lived API token.

The missing duplicate check is not hypothetical — **`pyproject.toml` says `0.1.1` and PyPI already has `0.1.1`**, so tagging today would have run the entire pipeline and then died at the upload with an opaque `File already exists` 400.

## Now

| Job | Gate |
|---|---|
| `verify` | resolve version from `pyproject.toml`; hard-fail if a tag push disagrees with it; hard-fail if the version is already on PyPI, with an actionable message instead of a late 400; then ruff + all 76 tests |
| `build` | `poetry build`, `twine check --strict`, and install the built wheel into a clean venv to confirm the console entry points work before anything is uploaded |
| `publish` | Trusted Publishing via OIDC (`id-token: write`) — **no API token** — scoped to a `pypi` environment where a human approval gate can be added. Skipped on a dry run |
| `release` | GitHub Release created with the distributions attached |

Actions bumped to `checkout@v4` / `setup-python@v5`; `poetry add ruff` replaced with a pinned install matching `.pre-commit-config.yaml`.

## Releasing, after this merges

```bash
poetry version minor
git commit -am "chore(release): 0.2.0"
git tag v0.2.0
git push && git push --tags
gh run watch
```

Rehearse the whole pipeline with the upload skipped:

```bash
gh workflow run publish.yaml -f dry_run=true
```

## Verified

Every `run:` block was extracted from the YAML and syntax-checked, and both guards were executed against the live PyPI API:

```
tag v0.1.1 == pyproject 0.1.1        -> rc=0  pass
tag v0.9.9 != pyproject 0.1.1        -> rc=1  "Tag v0.9.9 does not match pyproject.toml version 0.1.1"
workflow_dispatch (no tag)           -> rc=0  tag check correctly skipped
greenprompt 0.1.1 (already on PyPI)  -> rc=1  "already published on PyPI and cannot be replaced"
greenprompt 0.2.0 (free)             -> rc=0  pass
unknown package (first release)      -> rc=0  pass
```

This workflow only triggers on tags and `workflow_dispatch`, so it will not run on this PR. Its commit already passed the `test.yml` suite green on the branch.

## :warning: Required before the next release

1. **Configure Trusted Publishing** at https://pypi.org/manage/project/greenprompt/settings/publishing/ — owner `uday1201`, repository `greenprompt`, workflow `publish.yaml`, environment `pypi`. Until this exists the publish step cannot authenticate. `PYPI_API_TOKEN` can be deleted afterwards.
2. **Bump the version.** `0.1.1` is already published, so the guard will correctly refuse to release until it is bumped.

## Also

`.claude/commands/gp-release.md` is rewritten to describe this automated flow instead of a manual `poetry publish` and a checklist of bugs that were fixed months ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hMGz1dhtPZLBMr2oPHsQ3